### PR TITLE
Fix peerDependencies to be compatible with 'prop-types' package

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   "peerDependencies": {
     "final-form": "^1.3.2",
     "prop-types": "^15.6.0",
-    "react": "^15.0.0-0 || ^16.0.0-0"
+    "react": "^15.3.0 || ^16.0.0-0"
   },
   "jest": {
     "setupFiles": ["raf/polyfill"]


### PR DESCRIPTION
`prop-types` [requires](https://github.com/reactjs/prop-types#compatibility) `React ^15.3.0`