### PR TITLE
Value lifecycle

### DIFF
--- a/src/Field.js
+++ b/src/Field.js
@@ -25,6 +25,16 @@ export default class Field extends React.PureComponent<Props, State> {
   state: State
   unsubscribe: () => void
 
+  static contextTypes = {
+    reactFinalForm: PropTypes.object
+  }
+
+  static defaultProps = {
+    format: (value: ?any, name: string) => (value === undefined ? '' : value),
+    parse: (value: ?any, name: string) => (value === '' ? undefined : value),
+    normalize: (value: ?any, previousValue: ?any, allValues: Object) => value
+  }
+
   constructor(props: Props, context: ReactContext) {
     super(props, context)
     let initialState
@@ -62,6 +72,17 @@ export default class Field extends React.PureComponent<Props, State> {
 
   notify = (state: FieldState) => this.setState({ state })
 
+  parseAndNormalize = (value: ?any) => {
+    if (this.props.parse !== null) {
+      value = this.props.parse(value, this.props.name)
+    }
+    return this.props.normalize(
+      value,
+      this.state.state.value,
+      this.context.reactFinalForm.getState().values
+    )
+  }
+
   componentWillReceiveProps(nextProps: Props) {
     const { name, subscription } = nextProps
     if (
@@ -91,7 +112,7 @@ export default class Field extends React.PureComponent<Props, State> {
     onChange: (event: SyntheticInputEvent<*> | any) => {
       const value: any =
         event && event.target ? getValue(event, isReactNative) : event
-      this.state.state.change(value === '' ? undefined : value)
+      this.state.state.change(this.parseAndNormalize(value))
     },
     onFocus: (event: ?SyntheticFocusEvent<*>) => {
       this.state.state.focus()
@@ -104,6 +125,9 @@ export default class Field extends React.PureComponent<Props, State> {
       component,
       children,
       allowNull,
+      format,
+      parse,
+      normalize,
       subscription,
       validate,
       value: _value,
@@ -117,7 +141,10 @@ export default class Field extends React.PureComponent<Props, State> {
       name: ignoreName,
       ...meta
     } = this.state.state
-    if (value === undefined || (value === null && !allowNull)) {
+    if (format !== null) {
+      value = format(value, name)
+    }
+    if (value === null && !allowNull) {
       value = ''
     }
     const input = { name, value, ...this.handlers }
@@ -147,8 +174,4 @@ export default class Field extends React.PureComponent<Props, State> {
       `Field(${name})`
     )
   }
-}
-
-Field.contextTypes = {
-  reactFinalForm: PropTypes.object
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -62,7 +62,10 @@ export type FormProps = {
 
 export type FieldProps = {
   allowNull?: boolean
+  format: (value: any, name: string) => any | null
+  parse: (value: any, name: string) => any | null
   name: string
+  normalize: (value: any, previousValue: any, allValues: object) => any
   subscription?: FieldSubscription
   validate?: (value: any, allValues: object) => any
   value?: any

--- a/src/types.js.flow
+++ b/src/types.js.flow
@@ -63,7 +63,10 @@ export type FormProps = {
 
 export type FieldProps = {
   allowNull?: boolean,
+  format: (value: ?any, name: string) => ?any | null,
+  parse: (value: ?any, name: string) => ?any | null,
   name: string,
+  normalize: (value: ?any, previousValue: ?any, allValues: Object) => ?any,
   subscription?: FieldSubscription,
   validate?: (value: ?any, allValues: Object) => ?any,
   value?: any


### PR DESCRIPTION
The "value lifecycle" from Redux Form was a must-have feature for me and others (see #45 ). This PR introduces three new props for the `Field` component:
 - `format: (value: ?any, name: string) => ?any | null`
 - `parse: (value: ?any, name: string) => ?any | null`
 - `normalize: (value: ?any, previousValue: ?any, allValues: object) => ?any`

They work basically the same way as they do in Redux Form. The `allowNull` prop is still respected and applied after `format`. By default, `format` converts undefined to an empty string and `parse` converts an empty string to undefined. Either can be set to `null` explicitly opt-out of that behavior and of course a custom function can be provided for more advanced cases.

The `normalize` function is almost the same except it is not passed the `previousAllValues` since that is not easily available from within the `Field` component. I personally don't use the `normalize` prop so I can't think of a use case where the `previousAllValues` is needed.

So, there's no breaking changes and minimal amount of code/complexity introduced.