### PR TITLE
Value Lifecycle Props

### DIFF
--- a/src/ReactFinalForm.test.js
+++ b/src/ReactFinalForm.test.js
@@ -175,10 +175,11 @@ describe('ReactFinalForm', () => {
 
     const form = TestUtils.findRenderedDOMComponentWithTag(dom, 'form')
     TestUtils.Simulate.submit(form)
+    const formComponent = TestUtils.findRenderedComponentWithType(dom, Form)
 
     expect(onSubmit).toHaveBeenCalled()
     expect(onSubmit).toHaveBeenCalledTimes(1)
-    expect(onSubmit).toHaveBeenCalledWith({ foo: 'bar' })
+    expect(onSubmit).toHaveBeenCalledWith({ foo: 'bar' }, formComponent.form)
   })
 
   it('should reinitialize when initialValues prop changes', () => {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -62,7 +62,10 @@ export type FormProps = {
 
 export type FieldProps = {
   allowNull?: boolean
+  format: (value: any, name: string) => any | null
+  parse: (value: any, name: string) => any | null
   name: string
+  normalize: (value: any, previousValue: any, allValues: object) => any
   subscription?: FieldSubscription
   validate?: (value: any, allValues: object) => any
   value?: any

--- a/src/types.js.flow
+++ b/src/types.js.flow
@@ -63,11 +63,11 @@ export type FormProps = {
 
 export type FieldProps = {
   allowNull?: boolean,
-  format?: (value: ?any, name: string) => ?any | null,
-  parse?: (value: ?any, name: string) => ?any | null,
+  format: (value: ?any, name: string) => ?any | null,
+  parse: (value: ?any, name: string) => ?any | null,
   isEqual?: (a: any, b: any) => boolean,
   name: string,
-  normalize?: (value: ?any, previousValue: ?any, allValues: Object) => ?any,
+  normalize: (value: ?any, previousValue: ?any, allValues: Object) => ?any,
   subscription?: FieldSubscription,
   validate?: (value: ?any, allValues: Object) => ?any,
   validateFields?: string[],

--- a/src/types.js.flow
+++ b/src/types.js.flow
@@ -63,8 +63,11 @@ export type FormProps = {
 
 export type FieldProps = {
   allowNull?: boolean,
+  format: (value: ?any, name: string) => ?any | null,
+  parse: (value: ?any, name: string) => ?any | null,
   isEqual?: (a: any, b: any) => boolean,
   name: string,
+  normalize: (value: ?any, previousValue: ?any, allValues: Object) => ?any,
   subscription?: FieldSubscription,
   validate?: (value: ?any, allValues: Object) => ?any,
   validateFields?: string[],

--- a/src/types.js.flow
+++ b/src/types.js.flow
@@ -63,11 +63,11 @@ export type FormProps = {
 
 export type FieldProps = {
   allowNull?: boolean,
-  format: (value: ?any, name: string) => ?any | null,
-  parse: (value: ?any, name: string) => ?any | null,
+  format?: (value: ?any, name: string) => ?any | null,
+  parse?: (value: ?any, name: string) => ?any | null,
   isEqual?: (a: any, b: any) => boolean,
   name: string,
-  normalize: (value: ?any, previousValue: ?any, allValues: Object) => ?any,
+  normalize?: (value: ?any, previousValue: ?any, allValues: Object) => ?any,
   subscription?: FieldSubscription,
   validate?: (value: ?any, allValues: Object) => ?any,
   validateFields?: string[],


### PR DESCRIPTION
The "value lifecycle" from Redux Form was a must-have feature for me and others (see #45 ). This PR introduces three new props for the `Field` component:
 - `format: (value: ?any, name: string) => ?any | null`
 - `parse: (value: ?any, name: string) => ?any | null`
 - `normalize: (value: ?any, previousValue: ?any, allValues: object) => ?any`

They work basically the same way as they do in Redux Form. The `allowNull` prop is still respected and applied after `format`. By default, `format` converts undefined to an empty string and `parse` converts an empty string to undefined. Either can be set to `null` explicitly opt-out of that behavior and of course a custom function can be provided for more advanced cases.

The `normalize` function is almost the same except it is not passed the `previousAllValues` since that is not easily available from within the `Field` component. I personally don't use the `normalize` prop so I can't think of a use case where the `previousAllValues` is needed.

So, there's no breaking changes and minimal amount of code/complexity introduced.