### PR TITLE
typescript types fixes

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -50,7 +50,7 @@ export type FormSpyRenderProps = FormState
 
 export type RenderableProps<T> = Partial<{
   children: ((props: T) => React.ReactNode) | React.ReactNode
-  component: React.ComponentType
+  component: React.ComponentType<FieldRenderProps>
   render: (props: T) => React.ReactNode
 }>
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -68,6 +68,7 @@ export type FieldProps = {
   subscription?: FieldSubscription
   validate?: (value: any, allValues: object) => any
   value?: any
+  [otherProp: string]: any
 } & RenderableProps<FieldRenderProps>
 
 export type FormSpyProps = {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -50,7 +50,7 @@ export type FormSpyRenderProps = FormState
 
 export type RenderableProps<T> = Partial<{
   children: ((props: T) => React.ReactNode) | React.ReactNode
-  component: React.ComponentType<FieldRenderProps>
+  component: React.ComponentType<FieldRenderProps> | string
   render: (props: T) => React.ReactNode
 }>
 


### PR DESCRIPTION
The first commit includes a fix for #79.

In the second commit I included the type of the props of the component field, which allows us to write:

```ts
const InputAdapter = ({input, ...rest}: FieldRenderProps) => {
  return (
    <input {...input} {...rest}/>
  );
};
```

Without typescript complaining about not knowing `input` or `meta` props.
This makes the third party component example compile.

In the third commit, I added string as a legal value for `component` to match the basic example:

```ts
<Field
 name="firstName"
 component="input"
 />
```