### PR TITLE
Make errors `any` not `boolean`

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -24,11 +24,11 @@ export interface FieldRenderProps {
     // TODO: Make a diff of `FieldState` without all the functions
     active: boolean
     dirty: boolean
-    error: boolean
+    error: any
     initial: boolean
     invalid: boolean
     pristine: boolean
-    submitError: boolean
+    submitError: any
     submitFailed: boolean
     submitSucceeded: boolean
     touched: boolean

--- a/src/types.js.flow
+++ b/src/types.js.flow
@@ -25,11 +25,11 @@ export type FieldRenderProps = {
     // TODO: Make a diff of `FieldState` without all the functions
     active: boolean,
     dirty: boolean,
-    error: boolean,
+    error: any,
     initial: boolean,
     invalid: boolean,
     pristine: boolean,
-    submitError: boolean,
+    submitError: any,
     submitFailed: boolean,
     submitSucceeded: boolean,
     touched: boolean,


### PR DESCRIPTION
It's unlikely that the errors will ever be a boolean. Typically they are `null | string` but final-form supports `any` value.

<!--

👋 Hey, thanks for your interest in contributing to 🏁 React Final Form!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create an issue to first discuss any significant new
features.

Please try to keep your pull request focused in scope and avoid including
unrelated commits.

After you have submitted your pull request, we’ll try to get back to you as soon
as possible. We may suggest some changes or improvements.

Please format the code before submitting your pull request by running:

```
npm run precommit
```

https://github.com/final-form/react-final-form/blob/master/.github/CONTRIBUTING.md

-->
