### PR TITLE
Remove duplicated methods from FormRenderProps

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -49,13 +49,7 @@ export interface SubsetFormApi {
 
 export interface FormRenderProps extends FormState, SubsetFormApi {
   batch: (fn: () => void) => void
-  blur: (name: string) => void
-  change: (name: string, value: any) => void
-  focus: (name: string) => void
   handleSubmit: (event?: React.SyntheticEvent<HTMLFormElement>) => void
-  initialize: (values: object) => void
-  mutators?: { [key: string]: Function }
-  reset: () => void
 }
 
 export interface FormSpyRenderProps extends FormState, SubsetFormApi {}


### PR DESCRIPTION
These methods already appear in SubsetFormApi

<!--

👋 Hey, thanks for your interest in contributing to 🏁 React Final Form!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create an issue to first discuss any significant new
features.

Please try to keep your pull request focused in scope and avoid including
unrelated commits.

After you have submitted your pull request, we’ll try to get back to you as soon
as possible. We may suggest some changes or improvements.

Please format the code before submitting your pull request by running:

```
npm run precommit
```

https://github.com/final-form/react-final-form/blob/master/.github/CONTRIBUTING.md

-->
