### PR TITLE
RenderableProps component prop should still be given T

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -62,7 +62,7 @@ export interface FormSpyRenderProps extends FormState, SubsetFormApi {}
 
 export interface RenderableProps<T> {
   children?: ((props: T) => React.ReactNode) | React.ReactNode
-  component?: React.ComponentType<FieldRenderProps> | string
+  component?: React.ComponentType<T> | string
   render?: (props: T) => React.ReactNode
 }
 


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to 🏁 React Final Form!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create an issue to first discuss any significant new
features.

Please try to keep your pull request focused in scope and avoid including
unrelated commits.

After you have submitted your pull request, we’ll try to get back to you as soon
as possible. We may suggest some changes or improvements.

Please format the code before submitting your pull request by running:

```
npm run precommit
```

https://github.com/final-form/react-final-form/blob/master/.github/CONTRIBUTING.md

-->
