### PR TITLE
[typescript] possibly undefined mutators (on render) are difficult to use

### DIFF
--- a/src/ReactFinalForm.d.test.tsx
+++ b/src/ReactFinalForm.d.test.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import { Form, Field } from './index'
+import { Mutator } from 'final-form/dist'
 
 const onSubmit = async (values: any) => {
   console.log(values)
@@ -56,6 +57,39 @@ const simpleSubscription = () => (
     {({ handleSubmit, reset, submitting, pristine, values }) => (
       <form onSubmit={handleSubmit}>
         <button type="button" onClick={reset} disabled={submitting || pristine}>
+          Reset
+        </button>
+        <pre>{JSON.stringify(values)}</pre>
+      </form>
+    )}
+  </Form>
+)
+
+const setValue: Mutator = ([name, newValue], state, { changeValue }) => {
+  changeValue(state, name, value => newValue)
+}
+
+const mutated = () => (
+  <Form onSubmit={onSubmit} mutators={{ setValue }}>
+    {({
+      handleSubmit,
+      mutators: { setValue },
+      submitting,
+      pristine,
+      values
+    }) => (
+      <form onSubmit={handleSubmit}>
+        <Field
+          name="firstName"
+          component="input"
+          type="text"
+          placeholder="First Name"
+        />
+        <button
+          type="button"
+          onClick={e => setValue('firstName', 'Kevin')}
+          disabled={submitting || pristine}
+        >
           Reset
         </button>
         <pre>{JSON.stringify(values)}</pre>


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to 🏁 React Final Form!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create an issue to first discuss any significant new
features.

Please try to keep your pull request focused in scope and avoid including
unrelated commits.

After you have submitted your pull request, we’ll try to get back to you as soon
as possible. We may suggest some changes or improvements.

Please format the code before submitting your pull request by running:

```
npm run precommit
```

https://github.com/final-form/react-final-form/blob/master/.github/CONTRIBUTING.md

-->
WORK IN PROGRESS

In a strongly typed application,`FormRenderProps` `mutators` are difficult to use because they are possibly `undefined`.  

The first commit shows this pain (it errors), I'll look at making this a bit easier for typescript users.