### PR TITLE
chore: remove unnecessary raf polyfill

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11011,16 +11011,6 @@
       "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
       "dev": true
     },
-    "raf": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.0.tgz",
-      "integrity":
-        "sha512-pDP/NMRAXoTfrhCfyfSEwJAKLaxBU9eApMeBPB1TkDouZmvPerIClV8lTAd+uF8ZiTaVl69e1FCxQrAd/VTjGw==",
-      "dev": true,
-      "requires": {
-        "performance-now": "2.1.0"
-      }
-    },
     "randomatic": {
       "version": "1.1.7",
       "resolved":

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "prettier": "^1.11.1",
     "prettier-eslint-cli": "^4.7.1",
     "prop-types": "^15.6.1",
-    "raf": "^3.4.0",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "rollup": "^0.57.1",
@@ -73,9 +72,6 @@
     "final-form": "^4.2.0",
     "prop-types": "^15.6.0",
     "react": "^15.3.0 || ^16.0.0-0"
-  },
-  "jest": {
-    "setupFiles": ["raf/polyfill"]
   },
   "lint-staged": {
     "*.{js*,ts*,json,md,css}": ["prettier --write", "git add"]


### PR DESCRIPTION
Jest 22 comes with JSDOM 11 which has raf natively