### PR TITLE
Fix regression: meta.data

### DIFF
--- a/src/Field.js
+++ b/src/Field.js
@@ -169,6 +169,7 @@ export default class Field extends React.Component<Props, State> {
     const meta = {
       // this is to appease the Flow gods
       active: otherState.active,
+      data: otherState.data,
       dirty: otherState.dirty,
       dirtySinceLastSubmit: otherState.dirtySinceLastSubmit,
       error: otherState.error,


### PR DESCRIPTION
Adds `meta.data` back as it is listed as non-optional in the readme. 

Although it is flagged as optional in `final-form` it is always initialized with an object literal.

Updating to the newest `react-final-form` version also breaks the setFieldData-example: https://codesandbox.io/s/lrq5j4r8vl