### PR TITLE
Fix potential validation paused bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4582,11 +4582,11 @@
       }
     },
     "final-form": {
-      "version": "4.6.0",
+      "version": "4.6.1",
       "resolved":
-        "https://registry.npmjs.org/final-form/-/final-form-4.6.0.tgz",
+        "https://registry.npmjs.org/final-form/-/final-form-4.6.1.tgz",
       "integrity":
-        "sha512-mAC2k3xAAdgklB3fkduJveLOGC9PsttWybiq0AifG4bYmji2adI2bia7CmnLFIEUBs2Qqh77tgJIrxaRJ5LQwA==",
+        "sha512-1HX1hrODNsSQEDr0ZCskPX0MvByvCjg9iwj7zEiKvpBtuqJzI6nstZL75w+/vs00gVlPoUxqOixKzd9JWKGisg==",
       "dev": true
     },
     "find-parent-dir": {
@@ -11753,10 +11753,10 @@
       }
     },
     "rollup": {
-      "version": "0.58.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.58.1.tgz",
+      "version": "0.58.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.58.2.tgz",
       "integrity":
-        "sha512-m423aUHITpMlcqz0grLddNGxMpBC2yYmgKwSlKNXxEi8PfNKTknh69JDo1bB1T9ezJQeqAoyFo2+U3qMQ4/I6g==",
+        "sha512-RZVvCWm9BHOYloaE6LLiE/ibpjv1CmI8F8k0B0Cp+q1eezo3cswszJH1DN0djgzSlo0hjuuCmyeI+1XOYLl4wg==",
       "dev": true,
       "requires": {
         "@types/estree": "0.0.38",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "eslint-plugin-import": "^2.11.0",
     "eslint-plugin-jsx-a11y": "^6.0.2",
     "eslint-plugin-react": "^7.7.0",
-    "final-form": "^4.6.0",
+    "final-form": "^4.6.1",
     "flow-bin": "^0.70.0",
     "glow": "^1.2.2",
     "husky": "^0.14.3",
@@ -58,7 +58,7 @@
     "prop-types": "^15.6.1",
     "react": "^16.3.2",
     "react-dom": "^16.3.2",
-    "rollup": "^0.58.1",
+    "rollup": "^0.58.2",
     "rollup-plugin-babel": "^3.0.4",
     "rollup-plugin-commonjs": "^9.1.0",
     "rollup-plugin-flow": "^1.1.1",
@@ -69,7 +69,7 @@
     "typescript": "^2.8.1"
   },
   "peerDependencies": {
-    "final-form": "^4.2.0",
+    "final-form": "^4.6.1",
     "prop-types": "^15.6.0",
     "react": "^15.3.0 || ^16.0.0-0"
   },

--- a/src/ReactFinalForm.js
+++ b/src/ReactFinalForm.js
@@ -42,6 +42,7 @@ export default class ReactFinalForm extends React.Component<Props, State> {
   state: State
   form: FormApi
   mounted: boolean
+  resumeValidation: ?boolean
   unsubscriptions: Unsubscribe[]
 
   static childContextTypes = {
@@ -131,12 +132,13 @@ export default class ReactFinalForm extends React.Component<Props, State> {
 
   componentWillUpdate() {
     if (this.form) {
+      this.resumeValidation = !this.form.isValidationPaused()
       this.form.pauseValidation()
     }
   }
 
   componentDidUpdate() {
-    if (this.form) {
+    if (this.form && this.resumeValidation) {
       this.form.resumeValidation()
     }
   }
@@ -153,10 +155,7 @@ export default class ReactFinalForm extends React.Component<Props, State> {
         if (this.props[key] === nextProps[key]) {
           return
         }
-        // istanbul ignore next
-        if (this.form.setConfig) {
-          this.form.setConfig(key, nextProps[key])
-        }
+        this.form.setConfig(key, nextProps[key])
       }
     )
     // istanbul ignore next


### PR DESCRIPTION
`v3.4.0` includes a potential bug that would unpause validation on `componentDidUpdate()`. Discussed [here](https://github.com/final-form/final-form/issues/117#issuecomment-383633222).

This PR requires a peer dep to the latest version of `final-form@4.6.1`.