### PR TITLE
Add forceUpdate to FormRenderProps

### DIFF
--- a/README.md
+++ b/README.md
@@ -700,6 +700,10 @@ _**[DEPRECATED]** Use `form.reset()` instead_
 A function that resets the form values to their last initialized values.
 [See the 🏁 Final Form docs on `reset`](https://github.com/final-form/final-form#reset-initialvalues-object--void).
 
+#### `forceUpdate: () => void`
+
+Forces rerender of the Form component
+
 ### `FormSpyProps`
 
 These are the props that you pass to

--- a/src/ReactFinalForm.js
+++ b/src/ReactFinalForm.js
@@ -273,7 +273,8 @@ export default class ReactFinalForm extends React.Component<Props, State> {
             )
           }
           return this.form.reset(values)
-        })
+        }),
+      forceUpdate: this.forceUpdate.bind(this)
     }
     return renderComponent(
       {

--- a/src/ReactFinalForm.test.js
+++ b/src/ReactFinalForm.test.js
@@ -26,6 +26,21 @@ describe('ReactFinalForm', () => {
     expect(render).toHaveBeenCalledTimes(1)
   })
 
+  it('should re-render with forceUpdate render prop', () => {
+    let rerender
+    const render = jest.fn(({ forceUpdate }) => {
+      rerender = forceUpdate
+      return <div />
+    })
+    expect(render).not.toHaveBeenCalled()
+    TestUtils.renderIntoDocument(<Form onSubmit={onSubmitMock}>{render}</Form>)
+    expect(render).toHaveBeenCalled()
+    expect(render).toHaveBeenCalledTimes(1)
+
+    rerender()
+    expect(render).toHaveBeenCalledTimes(2)
+  })
+
   it('should print a warning with no render or children specified', () => {
     const spy = jest.spyOn(global.console, 'error').mockImplementation(() => {})
     TestUtils.renderIntoDocument(<Form onSubmit={onSubmitMock} />)

--- a/src/types.js.flow
+++ b/src/types.js.flow
@@ -55,6 +55,7 @@ export type SubsetFormApi = {
 
 export type FormRenderProps = {
   handleSubmit: (?SyntheticEvent<HTMLFormElement>) => ?Promise<?Object>,
+  forceUpdate: () => void,
   form: FormApi
 } & FormState &
   SubsetFormApi


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to 🏁 React Final Form!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create an issue to first discuss any significant new
features.

Please try to keep your pull request focused in scope and avoid including
unrelated commits.

After you have submitted your pull request, we’ll try to get back to you as soon
as possible. We may suggest some changes or improvements.

Please format the code before submitting your pull request by running:

```
npm run precommit
```

https://github.com/final-form/react-final-form/blob/master/.github/CONTRIBUTING.md

-->

There are cases when form state will change, but there are no subscriptions available to be notified.
Such is the case with field data.
In such cases, having a `forceUpdate` function can be useful, although of course the use should be discouraged.
A quick and dirty, but maybe necessary workaround in some cases, until a better solution comes around.