### PR TITLE
chore: do not install semantic-release on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ script:
   - npm start validate
 after_success:
   - npx codecov
-  - npm install --global semantic-release
+  # - npm install --global semantic-release
   # - semantic-release pre && npm publish && semantic-release post
 branches:
   only:


### PR DESCRIPTION
semantic-release is not used on Travis CI builds so it is not neeeded to install it.