### PR TITLE
chore: add Node.js 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ cache:
 notifications:
   email: false
 node_js:
+  - '10'
   - '8'
 script:
   - npm start validate


### PR DESCRIPTION
This adds Node.js 10 to the build matrix to make sure that the library also works on Node.js 10 (current stable).