### PR TITLE
add allowReinitializeValues prop to fix nested values in initialValues causing reinitialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -612,6 +612,13 @@ to apply to the form.
 
 [See the 🏁 Final Form docs on `initialValues`](https://github.com/final-form/final-form#initialvalues-object).
 
+#### `allowReinitializeValues: boolean`
+
+A boolean that indicates whether or not a change in the shallow values of
+`initialValues` should cause the form to reinitialize. Setting this to `true` is
+useful when you are re-rendering the `Form` component, and you are using nested
+values.
+
 #### `mutators?: { [string]: Mutator }`
 
 [See the 🏁 Final Form docs on `mutators`](https://github.com/final-form/final-form#mutators--string-function-).

--- a/src/ReactFinalForm.js
+++ b/src/ReactFinalForm.js
@@ -49,6 +49,10 @@ export default class ReactFinalForm extends React.Component<Props, State> {
     reactFinalForm: PropTypes.object
   }
 
+  static defaultProps = {
+    allowReinitializeValues: true,
+  }
+
   constructor(props: Props) {
     super(props)
     const {
@@ -146,6 +150,7 @@ export default class ReactFinalForm extends React.Component<Props, State> {
   componentWillReceiveProps(nextProps: Props) {
     if (
       nextProps.initialValues &&
+      nextProps.allowReinitializeValues &&
       !shallowEqual(this.props.initialValues, nextProps.initialValues)
     ) {
       this.form.initialize(nextProps.initialValues)

--- a/src/ReactFinalForm.test.js
+++ b/src/ReactFinalForm.test.js
@@ -254,6 +254,46 @@ describe('ReactFinalForm', () => {
     expect(renderInput.mock.calls[1][0].input.value).toBe('bar')
   })
 
+  it('should allow users to prevent reinitialize on initialValues changes', () => {
+    const renderInput = jest.fn(({ input }) => <input {...input} />)
+    class Container extends React.Component {
+      state = { initValues: { foo: "baz" } }
+
+      render() {
+        return (
+          <Form
+            onSubmit={onSubmitMock}
+            subscription={{ dirty: true }}
+            allowReinitializeValues={false}
+            initialValues={this.state.initValues}
+          >
+            {() => (
+              <form>
+                <Field name="foo" render={renderInput} />
+                <button
+                  type="button"
+                  onClick={() => this.setState({ initValues: { foo: 'bar' } })}
+                >
+                  Do nothing despite state change!
+                </button>
+              </form>
+            )}
+          </Form>
+        )
+      }
+    }
+
+    const dom = TestUtils.renderIntoDocument(<Container />)
+    expect(renderInput).toHaveBeenCalled()
+    expect(renderInput).toHaveBeenCalledTimes(1)
+
+    const init = TestUtils.findRenderedDOMComponentWithTag(dom, 'button')
+    TestUtils.Simulate.click(init)
+
+    expect(renderInput).toHaveBeenCalledTimes(2)
+    expect(renderInput.mock.calls[1][0].input.value).toBe('baz')
+  });
+
   it('should update when onSubmit changes', async () => {
     const oldOnSubmit = jest.fn()
     const newOnSubmit = jest.fn()

--- a/src/types.js.flow
+++ b/src/types.js.flow
@@ -72,7 +72,8 @@ export type RenderableProps<T> = {
 
 export type FormProps = {
   subscription?: FormSubscription,
-  decorators?: Decorator[]
+  decorators?: Decorator[],
+  allowReinitializeValues: boolean,
 } & Config &
   RenderableProps<FormRenderProps>
 


### PR DESCRIPTION
This is merely a suggestion for how to fix #256, inspired by [formik's enableReinitialize](https://github.com/jaredpalmer/formik#enablereinitialize-boolean) and `[redux-form's enableReinitialize](https://redux-form.com/7.3.0/docs/api/reduxform.md/#-code-enablereinitialize-boolean-code-optional-). I'll admit that I just remembered the concept and didn't look at the names of those functions until just now, otherwise I probably would have chosen something a little more in-keeping!

I can change the name or the approach if you'd like. Just let me know what direction you'd like to take.