### PR TITLE
Add AsyncTypeahead and Redux example

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ const MyForm = () => (
   * [Async Redux Submission](#async-redux-submission)
   * [Declarative Form Rules](#declarative-form-rules)
   * [Format String By Pattern](#format-string-by-pattern)
+  * [AsyncTypeahead and Redux](#asynctypeahead-redux)
 * [Rendering](#rendering)
 * [API](#api)
   * [`Field : React.ComponentType<FieldProps>`](#field--reactcomponenttypefieldprops)
@@ -382,6 +383,10 @@ What if you could define rules to update fields when other fields change _as com
 ### [Format String By Pattern](https://codesandbox.io/s/no20p7z3l)
 
 Demonstrates how to use the library `format-string-by-pattern` to create input masks for your 🏁 React Final Form fields.
+
+### [AsyncTypeahead and Redux](https://codesandbox.io/s/5m4w2909k)
+
+Demonstrates creating an `AsyncTypeahead` to select github users, while storing the search results in the redux store and the form state (selected github users) via `react-final-form`. Also makes use of the [`setFieldData` mutator](https://github.com/final-form/final-form-set-field-data).
 
 ## Rendering
 


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to 🏁 React Final Form!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create an issue to first discuss any significant new
features.

Please try to keep your pull request focused in scope and avoid including
unrelated commits.

After you have submitted your pull request, we’ll try to get back to you as soon
as possible. We may suggest some changes or improvements.

Please format the code before submitting your pull request by running:

```
npm run precommit
```

https://github.com/final-form/react-final-form/blob/master/.github/CONTRIBUTING.md

-->
May be useful to someone trying to use the `AsyncTypeahead` along with `redux` and `react-final-form`. I am quite happy with this solution. Also, as far as I am concerned, this closes https://github.com/final-form/final-form/issues/122