### PR TITLE
Changed to not require RFF update when new FF config props are added

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -145,17 +145,17 @@
       "dev": true
     },
     "@types/node": {
-      "version": "10.1.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.1.4.tgz",
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.3.1.tgz",
       "integrity":
-        "sha512-GpQxofkdlHYxjHad98UUdNoMO7JrmzQZoAaghtNg14Gwg7YkohcrCoJEcEMSgllx4VIZ+mYw7ZHjfaeIagP/rg==",
+        "sha512-IsX9aDHDzJohkm3VCDB8tkzl5RQ34E/PFA29TQk6uDGb7Oc869ZBtmdKVDBzY3+h9GnXB8ssrRXEPVZrlIOPOw==",
       "dev": true
     },
     "@types/react": {
-      "version": "16.3.14",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.3.14.tgz",
+      "version": "16.3.16",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.3.16.tgz",
       "integrity":
-        "sha512-wNUGm49fPl7eE2fnYdF0v5vSOrUMdKMQD/4NwtQRnb6mnPwtkhabmuFz37eq90+hhyfz0pWd38jkZHOcaZ6LGw==",
+        "sha512-fM7YX3Q9a915DXi8T06F8906bWv19sbkVO+k5PUYRIWXU2PINLEHbMMGgySem2phwF6En0+HGI6MOrobp+Ya1g==",
       "dev": true,
       "requires": {
         "csstype": "^2.2.0"
@@ -175,10 +175,10 @@
       "dev": true
     },
     "acorn": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.6.0.tgz",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.6.2.tgz",
       "integrity":
-        "sha512-QatFQ4C0n+PLqemyC6zXEv04tSqRR0hRqe+uGKPEVgKe2G8kl8wJvHzRYWwz6vqqEqt6idPVMFojZ4P1zlyAzQ==",
+        "sha512-zUzo1E5dI2Ey8+82egfnttyMlMZ2y0D8xOCO3PNPPlYXpl8NZvF6Qk9L9BEtJs+43FqEmfBViDqc5d1ckRDguw==",
       "dev": true
     },
     "acorn-globals": {
@@ -327,13 +327,14 @@
       "dev": true
     },
     "append-transform": {
-      "version": "0.4.0",
+      "version": "1.0.0",
       "resolved":
-        "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
-      "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
+        "https://registry.npmjs.org/append-transform/-/append-transform-1.0.0.tgz",
+      "integrity":
+        "sha512-P009oYkeHyU742iSZJzZZywj4QRJdnTWffaKuJQLablCZ1uz6/cW4yaRgcDaoQ+uwOxxnt0gRUcwfsNP2ri0gw==",
       "dev": true,
       "requires": {
-        "default-require-extensions": "^1.0.0"
+        "default-require-extensions": "^2.0.0"
       }
     },
     "aproba": {
@@ -2108,11 +2109,11 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30000847",
+      "version": "1.0.30000849",
       "resolved":
-        "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000847.tgz",
+        "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000849.tgz",
       "integrity":
-        "sha512-Weo+tRtVWcN2da782Ebx/27hFNEb+KP+uP6tdqAa+2S5bp1zOJhVH9tEpDygagrfvU4QjeuPwi/5VGsgT4SLaA==",
+        "sha512-hlkWpyGJTDjjim2m+nvvHiEqt2PZuPdB9yYRbys5P/T179Aq7YgMF6tnM489voTfqMLtJhqmOZNfghxWjjT8jg==",
       "dev": true
     },
     "capture-exit": {
@@ -3031,13 +3032,22 @@
       "dev": true
     },
     "default-require-extensions": {
-      "version": "1.0.0",
+      "version": "2.0.0",
       "resolved":
-        "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
-      "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
+        "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
+      "integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
       "dev": true,
       "requires": {
-        "strip-bom": "^2.0.0"
+        "strip-bom": "^3.0.0"
+      },
+      "dependencies": {
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved":
+            "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
+        }
       }
     },
     "define-properties": {
@@ -3332,11 +3342,11 @@
       }
     },
     "es-abstract": {
-      "version": "1.11.0",
+      "version": "1.12.0",
       "resolved":
-        "https://registry.npmjs.org/es-abstract/-/es-abstract-1.11.0.tgz",
+        "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
       "integrity":
-        "sha512-ZnQrE/lXTTQ39ulXZ+J1DTFazV9qBy61x2bY071B+qGco8Z8q1QddsLdt/EF8Ai9hcWH72dWS0kFqXLxOxqslA==",
+        "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
       "dev": true,
       "requires": {
         "es-to-primitive": "^1.1.1",
@@ -3529,11 +3539,11 @@
       }
     },
     "eslint-plugin-flowtype": {
-      "version": "2.48.0",
+      "version": "2.49.3",
       "resolved":
-        "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.48.0.tgz",
+        "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.49.3.tgz",
       "integrity":
-        "sha512-D9zX5os88JjrIdM2eLldLYL8xJcbPIiMMT6n4fBFcAk/r6lGc+XPKOv5hpHt6OwfVrZ4TVoQAcKPyZB1hS0Ovg==",
+        "sha512-wO0S4QbXPReKtydxbY5A0UieOaF9jBO5BMuxYPQOTa082JCpKEoC7+o3fnKsVVycwX47lvqLiUGRsWauCiA9aw==",
       "dev": true,
       "requires": {
         "lodash": "^4.17.10"
@@ -3651,17 +3661,17 @@
       }
     },
     "eslint-plugin-react": {
-      "version": "7.8.2",
+      "version": "7.9.1",
       "resolved":
-        "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.8.2.tgz",
+        "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.9.1.tgz",
       "integrity":
-        "sha512-H3ne8ob4Bn6NXSN9N9twsn7t8dyHT5bF/ibQepxIHi6JiPIdC2gXlfYvZYucbdrWio4FxBq7Z4mSauQP+qmMkQ==",
+        "sha512-uvq+2ZkiqzjwF+pMZ8xqIC3pChV4KviPvvPIyQOvKWnjtvyW3iGfHIRqVumw05L3itby0QGmA4VdBA9m1OdMmg==",
       "dev": true,
       "requires": {
-        "doctrine": "^2.0.2",
-        "has": "^1.0.1",
+        "doctrine": "^2.1.0",
+        "has": "^1.0.2",
         "jsx-ast-utils": "^2.0.1",
-        "prop-types": "^15.6.0"
+        "prop-types": "^15.6.1"
       }
     },
     "eslint-rule-composer": {
@@ -4334,32 +4344,24 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-          "integrity":
-            "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved":
-            "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "bundled": true,
           "dev": true
         },
         "aproba": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-          "integrity":
-            "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.4",
-          "resolved":
-            "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-          "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -4369,17 +4371,12 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "resolved":
-            "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+          "bundled": true,
           "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "resolved":
-            "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-          "integrity":
-            "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
@@ -4388,45 +4385,34 @@
         },
         "chownr": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
-          "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved":
-            "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+          "bundled": true,
           "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved":
-            "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+          "bundled": true,
           "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "resolved":
-            "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+          "bundled": true,
           "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "resolved":
-            "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity":
-            "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -4435,35 +4421,25 @@
         },
         "deep-extend": {
           "version": "0.5.1",
-          "resolved":
-            "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
-          "integrity":
-            "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "resolved":
-            "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "resolved":
-            "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-          "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "resolved":
-            "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
-          "integrity":
-            "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -4472,16 +4448,13 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved":
-            "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -4497,9 +4470,7 @@
         },
         "glob": {
           "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity":
-            "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -4513,18 +4484,13 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "resolved":
-            "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.21",
-          "resolved":
-            "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.21.tgz",
-          "integrity":
-            "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -4533,10 +4499,7 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "resolved":
-            "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
-          "integrity":
-            "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -4545,9 +4508,7 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved":
-            "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -4557,24 +4518,18 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved":
-            "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "bundled": true,
           "dev": true
         },
         "ini": {
           "version": "1.3.5",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-          "integrity":
-            "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved":
-            "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "number-is-nan": "^1.0.0"
@@ -4582,17 +4537,13 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved":
-            "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity":
-            "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"
@@ -4600,17 +4551,12 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved":
-            "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "bundled": true,
           "dev": true
         },
         "minipass": {
           "version": "2.2.4",
-          "resolved":
-            "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
-          "integrity":
-            "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "safe-buffer": "^5.1.1",
@@ -4619,10 +4565,7 @@
         },
         "minizlib": {
           "version": "1.1.0",
-          "resolved":
-            "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
-          "integrity":
-            "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -4631,8 +4574,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "minimist": "0.0.8"
@@ -4640,16 +4582,13 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "needle": {
           "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.0.tgz",
-          "integrity":
-            "sha512-eFagy6c+TYayorXw/qtAdSvaUpEbBsDwDyxYFgLZ0lTojfH7K+OdBqAF7TAFwDokJaGpubpSGG0wO3iC0XPi8w==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -4660,10 +4599,7 @@
         },
         "node-pre-gyp": {
           "version": "0.10.0",
-          "resolved":
-            "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.10.0.tgz",
-          "integrity":
-            "sha512-G7kEonQLRbcA/mOoFoxvlMrw6Q6dPf92+t/l0DFSMuSlDoWaI9JWIyPwK0jyE1bph//CUEL65/Fz1m2vJbmjQQ==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -4681,8 +4617,7 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -4692,19 +4627,13 @@
         },
         "npm-bundled": {
           "version": "1.0.3",
-          "resolved":
-            "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.3.tgz",
-          "integrity":
-            "sha512-ByQ3oJ/5ETLyglU2+8dBObvhfWXX8dtPZDMePCahptliFX2iIuhyEszyFk401PZUNQH20vvdW5MLjJxkwU80Ow==",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
           "version": "1.1.10",
-          "resolved":
-            "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.1.10.tgz",
-          "integrity":
-            "sha512-AQC0Dyhzn4EiYEfIUjCdMl0JJ61I2ER9ukf/sLxJUcZHfo+VyEfz2rMJgLZSS1v30OxPQe1cN0LZA1xbcaVfWA==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -4714,9 +4643,7 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-          "integrity":
-            "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -4728,23 +4655,18 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved":
-            "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+          "bundled": true,
           "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved":
-            "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "wrappy": "1"
@@ -4752,25 +4674,19 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved":
-            "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "resolved":
-            "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-          "integrity":
-            "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -4780,26 +4696,19 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved":
-            "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "resolved":
-            "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-          "integrity":
-            "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.7.tgz",
-          "integrity":
-            "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -4811,9 +4720,7 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "resolved":
-                "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+              "bundled": true,
               "dev": true,
               "optional": true
             }
@@ -4821,10 +4728,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved":
-            "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-          "integrity":
-            "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -4839,9 +4743,7 @@
         },
         "rimraf": {
           "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-          "integrity":
-            "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -4850,58 +4752,42 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "resolved":
-            "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-          "integrity":
-            "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+          "bundled": true,
           "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "resolved":
-            "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-          "integrity":
-            "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-          "integrity":
-            "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "semver": {
           "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-          "integrity":
-            "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved":
-            "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved":
-            "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved":
-            "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "code-point-at": "^1.0.0",
@@ -4911,10 +4797,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved":
-            "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity":
-            "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -4923,9 +4806,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved":
-            "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -4933,17 +4814,13 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved":
-            "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "tar": {
           "version": "4.4.1",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.1.tgz",
-          "integrity":
-            "sha512-O+v1r9yN4tOsvl90p5HAP4AEqbYhx4036AGMm075fH9F8Qwi3oJ+v4u50FkT/KkvywNGtwkk0zRI+8eYm1X/xg==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -4958,18 +4835,13 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "resolved":
-            "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "wide-align": {
           "version": "1.1.2",
-          "resolved":
-            "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-          "integrity":
-            "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -4978,14 +4850,12 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+          "bundled": true,
           "dev": true
         },
         "yallist": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
-          "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
+          "bundled": true,
           "dev": true
         }
       }
@@ -5417,12 +5287,13 @@
       }
     },
     "has": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
-      "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity":
+        "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "dev": true,
       "requires": {
-        "function-bind": "^1.0.2"
+        "function-bind": "^1.1.1"
       }
     },
     "has-ansi": {
@@ -6215,14 +6086,14 @@
       "dev": true
     },
     "istanbul-lib-hook": {
-      "version": "1.2.0",
+      "version": "1.2.1",
       "resolved":
-        "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.2.0.tgz",
+        "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.2.1.tgz",
       "integrity":
-        "sha512-p3En6/oGkFQV55Up8ZPC2oLxvgSxD8CzA0yBrhRZSh3pfv3OFj9aSGVC0yoerAi/O4u7jUVnOGVX1eVFM+0tmQ==",
+        "sha512-eLAMkPG9FU0v5L02lIkcj/2/Zlz9OuluaXikdr5iStk8FDbSwAixTK9TkYxbF0eNnzAJTwM2fkV2A1tpsIp4Jg==",
       "dev": true,
       "requires": {
-        "append-transform": "^0.4.0"
+        "append-transform": "^1.0.0"
       }
     },
     "istanbul-lib-instrument": {
@@ -7146,10 +7017,10 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
       "integrity":
-        "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
+        "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -7316,11 +7187,11 @@
       }
     },
     "lint-staged": {
-      "version": "7.1.2",
+      "version": "7.1.3",
       "resolved":
-        "https://registry.npmjs.org/lint-staged/-/lint-staged-7.1.2.tgz",
+        "https://registry.npmjs.org/lint-staged/-/lint-staged-7.1.3.tgz",
       "integrity":
-        "sha512-IEh09VAFuFYZh376kh61Dwg1Nifs511868okujVqrESDkTqVZ3/2rZ1kFXEf0DtUHPc2HtyemJ03W6ISqRYdLQ==",
+        "sha512-D06sTSzsLP7bSnExH92zM/BK1Bgw4jHNEuhzYWlx7Kmy6b4AoPfK1vjE3n0G4qZwy6PLuqW9wYQ1WIC1fIU9Rg==",
       "dev": true,
       "requires": {
         "app-root-path": "^2.0.1",
@@ -7333,7 +7204,7 @@
         "find-parent-dir": "^0.3.0",
         "is-glob": "^4.0.0",
         "is-windows": "^1.0.2",
-        "jest-validate": "^22.4.0",
+        "jest-validate": "^23.0.0",
         "listr": "^0.14.1",
         "lodash": "^4.17.5",
         "log-symbols": "^2.2.0",
@@ -7348,48 +7219,6 @@
         "stringify-object": "^3.2.2"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved":
-            "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "arr-diff": {
-          "version": "2.0.0",
-          "resolved":
-            "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-          "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-          "dev": true,
-          "requires": {
-            "arr-flatten": "^1.0.1"
-          }
-        },
-        "array-unique": {
-          "version": "0.2.1",
-          "resolved":
-            "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-          "dev": true
-        },
-        "braces": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-          "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-          "dev": true,
-          "requires": {
-            "expand-range": "^1.8.1",
-            "preserve": "^0.2.0",
-            "repeat-element": "^1.1.2"
-          }
-        },
-        "callsites": {
-          "version": "2.0.0",
-          "resolved":
-            "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
-          "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
-          "dev": true
-        },
         "execa": {
           "version": "0.9.0",
           "resolved": "https://registry.npmjs.org/execa/-/execa-0.9.0.tgz",
@@ -7406,312 +7235,11 @@
             "strip-eof": "^1.0.0"
           }
         },
-        "expand-brackets": {
-          "version": "0.1.5",
-          "resolved":
-            "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-          "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-          "dev": true,
-          "requires": {
-            "is-posix-bracket": "^0.1.0"
-          }
-        },
-        "expect": {
-          "version": "22.4.3",
-          "resolved": "https://registry.npmjs.org/expect/-/expect-22.4.3.tgz",
-          "integrity":
-            "sha512-XcNXEPehqn8b/jm8FYotdX0YrXn36qp4HWlrVT4ktwQas1l1LPxiVWncYnnL2eyMtKAmVIaG0XAp0QlrqJaxaA==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.0",
-            "jest-diff": "^22.4.3",
-            "jest-get-type": "^22.4.3",
-            "jest-matcher-utils": "^22.4.3",
-            "jest-message-util": "^22.4.3",
-            "jest-regex-util": "^22.4.3"
-          }
-        },
-        "extglob": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-          "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        },
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved":
-            "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
-        },
-        "jest-config": {
-          "version": "22.4.4",
-          "resolved":
-            "https://registry.npmjs.org/jest-config/-/jest-config-22.4.4.tgz",
-          "integrity":
-            "sha512-9CKfo1GC4zrXSoMLcNeDvQBfgtqGTB1uP8iDIZ97oB26RCUb886KkKWhVcpyxVDOUxbhN+uzcBCeFe7w+Iem4A==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.0.1",
-            "glob": "^7.1.1",
-            "jest-environment-jsdom": "^22.4.1",
-            "jest-environment-node": "^22.4.1",
-            "jest-get-type": "^22.1.0",
-            "jest-jasmine2": "^22.4.4",
-            "jest-regex-util": "^22.1.0",
-            "jest-resolve": "^22.4.2",
-            "jest-util": "^22.4.1",
-            "jest-validate": "^22.4.4",
-            "pretty-format": "^22.4.0"
-          }
-        },
-        "jest-diff": {
-          "version": "22.4.3",
-          "resolved":
-            "https://registry.npmjs.org/jest-diff/-/jest-diff-22.4.3.tgz",
-          "integrity":
-            "sha512-/QqGvCDP5oZOF6PebDuLwrB2BMD8ffJv6TAGAdEVuDx1+uEgrHpSFrfrOiMRx2eJ1hgNjlQrOQEHetVwij90KA==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.0.1",
-            "diff": "^3.2.0",
-            "jest-get-type": "^22.4.3",
-            "pretty-format": "^22.4.3"
-          }
-        },
-        "jest-environment-jsdom": {
-          "version": "22.4.3",
-          "resolved":
-            "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-22.4.3.tgz",
-          "integrity":
-            "sha512-FviwfR+VyT3Datf13+ULjIMO5CSeajlayhhYQwpzgunswoaLIPutdbrnfUHEMyJCwvqQFaVtTmn9+Y8WCt6n1w==",
-          "dev": true,
-          "requires": {
-            "jest-mock": "^22.4.3",
-            "jest-util": "^22.4.3",
-            "jsdom": "^11.5.1"
-          }
-        },
-        "jest-environment-node": {
-          "version": "22.4.3",
-          "resolved":
-            "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-22.4.3.tgz",
-          "integrity":
-            "sha512-reZl8XF6t/lMEuPWwo9OLfttyC26A5AMgDyEQ6DBgZuyfyeNUzYT8BFo6uxCCP/Av/b7eb9fTi3sIHFPBzmlRA==",
-          "dev": true,
-          "requires": {
-            "jest-mock": "^22.4.3",
-            "jest-util": "^22.4.3"
-          }
-        },
-        "jest-jasmine2": {
-          "version": "22.4.4",
-          "resolved":
-            "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-22.4.4.tgz",
-          "integrity":
-            "sha512-nK3vdUl50MuH7vj/8at7EQVjPGWCi3d5+6aCi7Gxy/XMWdOdbH1qtO/LjKbqD8+8dUAEH+BVVh7HkjpCWC1CSw==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.0.1",
-            "co": "^4.6.0",
-            "expect": "^22.4.0",
-            "graceful-fs": "^4.1.11",
-            "is-generator-fn": "^1.0.0",
-            "jest-diff": "^22.4.0",
-            "jest-matcher-utils": "^22.4.0",
-            "jest-message-util": "^22.4.0",
-            "jest-snapshot": "^22.4.0",
-            "jest-util": "^22.4.1",
-            "source-map-support": "^0.5.0"
-          }
-        },
-        "jest-matcher-utils": {
-          "version": "22.4.3",
-          "resolved":
-            "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-22.4.3.tgz",
-          "integrity":
-            "sha512-lsEHVaTnKzdAPR5t4B6OcxXo9Vy4K+kRRbG5gtddY8lBEC+Mlpvm1CJcsMESRjzUhzkz568exMV1hTB76nAKbA==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.0.1",
-            "jest-get-type": "^22.4.3",
-            "pretty-format": "^22.4.3"
-          }
-        },
-        "jest-message-util": {
-          "version": "22.4.3",
-          "resolved":
-            "https://registry.npmjs.org/jest-message-util/-/jest-message-util-22.4.3.tgz",
-          "integrity":
-            "sha512-iAMeKxhB3Se5xkSjU0NndLLCHtP4n+GtCqV0bISKA5dmOXQfEbdEmYiu2qpnWBDCQdEafNDDU6Q+l6oBMd/+BA==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.0.0-beta.35",
-            "chalk": "^2.0.1",
-            "micromatch": "^2.3.11",
-            "slash": "^1.0.0",
-            "stack-utils": "^1.0.1"
-          },
-          "dependencies": {
-            "is-glob": {
-              "version": "2.0.1",
-              "resolved":
-                "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-              "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-              "dev": true,
-              "requires": {
-                "is-extglob": "^1.0.0"
-              }
-            },
-            "micromatch": {
-              "version": "2.3.11",
-              "resolved":
-                "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-              "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-              "dev": true,
-              "requires": {
-                "arr-diff": "^2.0.0",
-                "array-unique": "^0.2.1",
-                "braces": "^1.8.2",
-                "expand-brackets": "^0.1.4",
-                "extglob": "^0.3.1",
-                "filename-regex": "^2.0.0",
-                "is-extglob": "^1.0.0",
-                "is-glob": "^2.0.1",
-                "kind-of": "^3.0.2",
-                "normalize-path": "^2.0.1",
-                "object.omit": "^2.0.0",
-                "parse-glob": "^3.0.4",
-                "regex-cache": "^0.4.2"
-              }
-            }
-          }
-        },
-        "jest-mock": {
-          "version": "22.4.3",
-          "resolved":
-            "https://registry.npmjs.org/jest-mock/-/jest-mock-22.4.3.tgz",
-          "integrity":
-            "sha512-+4R6mH5M1G4NK16CKg9N1DtCaFmuxhcIqF4lQK/Q1CIotqMs/XBemfpDPeVZBFow6iyUNu6EBT9ugdNOTT5o5Q==",
-          "dev": true
-        },
-        "jest-regex-util": {
-          "version": "22.4.3",
-          "resolved":
-            "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-22.4.3.tgz",
-          "integrity":
-            "sha512-LFg1gWr3QinIjb8j833bq7jtQopiwdAs67OGfkPrvy7uNUbVMfTXXcOKXJaeY5GgjobELkKvKENqq1xrUectWg==",
-          "dev": true
-        },
-        "jest-resolve": {
-          "version": "22.4.3",
-          "resolved":
-            "https://registry.npmjs.org/jest-resolve/-/jest-resolve-22.4.3.tgz",
-          "integrity":
-            "sha512-u3BkD/MQBmwrOJDzDIaxpyqTxYH+XqAXzVJP51gt29H8jpj3QgKof5GGO2uPGKGeA1yTMlpbMs1gIQ6U4vcRhw==",
-          "dev": true,
-          "requires": {
-            "browser-resolve": "^1.11.2",
-            "chalk": "^2.0.1"
-          }
-        },
-        "jest-snapshot": {
-          "version": "22.4.3",
-          "resolved":
-            "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-22.4.3.tgz",
-          "integrity":
-            "sha512-JXA0gVs5YL0HtLDCGa9YxcmmV2LZbwJ+0MfyXBBc5qpgkEYITQFJP7XNhcHFbUvRiniRpRbGVfJrOoYhhGE0RQ==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.0.1",
-            "jest-diff": "^22.4.3",
-            "jest-matcher-utils": "^22.4.3",
-            "mkdirp": "^0.5.1",
-            "natural-compare": "^1.4.0",
-            "pretty-format": "^22.4.3"
-          }
-        },
-        "jest-util": {
-          "version": "22.4.3",
-          "resolved":
-            "https://registry.npmjs.org/jest-util/-/jest-util-22.4.3.tgz",
-          "integrity":
-            "sha512-rfDfG8wyC5pDPNdcnAlZgwKnzHvZDu8Td2NJI/jAGKEGxJPYiE4F0ss/gSAkG4778Y23Hvbz+0GMrDJTeo7RjQ==",
-          "dev": true,
-          "requires": {
-            "callsites": "^2.0.0",
-            "chalk": "^2.0.1",
-            "graceful-fs": "^4.1.11",
-            "is-ci": "^1.0.10",
-            "jest-message-util": "^22.4.3",
-            "mkdirp": "^0.5.1",
-            "source-map": "^0.6.0"
-          }
-        },
-        "jest-validate": {
-          "version": "22.4.4",
-          "resolved":
-            "https://registry.npmjs.org/jest-validate/-/jest-validate-22.4.4.tgz",
-          "integrity":
-            "sha512-dmlf4CIZRGvkaVg3fa0uetepcua44DHtktHm6rcoNVtYlpwe6fEJRkMFsaUVcFHLzbuBJ2cPw9Gl9TKfnzMVwg==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.0.1",
-            "jest-config": "^22.4.4",
-            "jest-get-type": "^22.1.0",
-            "leven": "^2.1.0",
-            "pretty-format": "^22.4.0"
-          }
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "dev": true,
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        },
         "pify": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
-        },
-        "pretty-format": {
-          "version": "22.4.3",
-          "resolved":
-            "https://registry.npmjs.org/pretty-format/-/pretty-format-22.4.3.tgz",
-          "integrity":
-            "sha512-S4oT9/sT6MN7/3COoOy+ZJeA92VmOnveLHgrwBE3Z1W5N9S2A1QGNYiE1z75DAENbJrXXUb+OWXhpJcg05QKQQ==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^3.0.0",
-            "ansi-styles": "^3.2.0"
-          }
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved":
-            "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity":
-            "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        },
-        "source-map-support": {
-          "version": "0.5.6",
-          "resolved":
-            "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.6.tgz",
-          "integrity":
-            "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
-          "dev": true,
-          "requires": {
-            "buffer-from": "^1.0.0",
-            "source-map": "^0.6.0"
-          }
         }
       }
     },
@@ -8991,10 +8519,10 @@
       "dev": true
     },
     "nwsapi": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.0.1.tgz",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.0.2.tgz",
       "integrity":
-        "sha512-xOJJb7kAAGy6UOklbaIPA0iu/27VMHfAbMUgYJlXz4qRXytIkPGM2vwfbxa+tbaqcqHNsP6RN4eDZlePelWKpQ==",
+        "sha512-wAvMV1QgoYPvqfcAmX1M86SyZA3SnNT6UNvjqO/pKHjIZzhMpPHjCTOWdOfkmUknjnvjDq09wDiBaHAzXSLiSA==",
       "dev": true
     },
     "oauth-sign": {
@@ -10288,6 +9816,13 @@
         "prop-types": "^15.6.0"
       }
     },
+    "react-lifecycles-compat": {
+      "version": "3.0.4",
+      "resolved":
+        "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "integrity":
+        "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
     "read-pkg": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
@@ -10732,10 +10267,10 @@
       }
     },
     "rollup": {
-      "version": "0.59.4",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.59.4.tgz",
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.60.0.tgz",
       "integrity":
-        "sha512-ISiMqq/aJa+57QxX2MRcvLESHdJ7wSavmr6U1euMr+6UgFe6KM+3QANrYy8LQofwhTC1I7BcAdlLnDiaODs1BA==",
+        "sha512-uZrBe2uFy9E0FO3fb1T5ZEkUeZrF2rQIGWYmEoJ39NQegaJGQriPgJIGyKW3RkPwEIFH5X0C3HfqAgDdjE4CdQ==",
       "dev": true,
       "requires": {
         "@types/estree": "0.0.39",
@@ -11089,11 +10624,11 @@
           "dev": true
         },
         "uglify-js": {
-          "version": "3.3.28",
+          "version": "3.4.0",
           "resolved":
-            "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.28.tgz",
+            "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.0.tgz",
           "integrity":
-            "sha512-68Rc/aA6cswiaQ5SrE979UJcXX+ADA1z33/ZsPd+fbAiVdjZ16OXdbtGO+rJUUBgK6qdf3SOPhQf3K/ybF5Miw==",
+            "sha512-Jcf5naPkX3rVPSQpRn9Vm6Rr572I1gTtR9LnqKgXjmOgfYQ/QS0V2WRStFR53Bdj520M66aCZqt9uzYXgtGrJQ==",
           "dev": true,
           "requires": {
             "commander": "~2.15.0",
@@ -11627,9 +11162,9 @@
       "dev": true
     },
     "sshpk": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
-      "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
+      "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
       "dev": true,
       "requires": {
         "asn1": "~0.2.3",
@@ -11639,6 +11174,7 @@
         "ecc-jsbn": "~0.1.1",
         "getpass": "^0.1.1",
         "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
       }
     },
@@ -12263,11 +11799,11 @@
       "dev": true
     },
     "typescript": {
-      "version": "2.8.4",
+      "version": "2.9.1",
       "resolved":
-        "https://registry.npmjs.org/typescript/-/typescript-2.8.4.tgz",
+        "https://registry.npmjs.org/typescript/-/typescript-2.9.1.tgz",
       "integrity":
-        "sha512-IIU5cN1mR5J3z9jjdESJbnxikTrEz3lzAw/D0Tf45jHpBp55nY31UkUvmVHoffCfKHTqJs3fCLPDxknQTTFegQ==",
+        "sha512-h6pM2f/GDchCFlldnriOhs1QHuwbnmj6/v7499eMHqPeW4V2G0elua2eIc2nu8v2NdHV0Gm+tzX83Hr6nUFjQA==",
       "dev": true
     },
     "typescript-eslint-parser": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "prop-types": "^15.6.1",
     "react": "^16.3.2",
     "react-dom": "^16.3.2",
-    "rollup": "^0.59.4",
+    "rollup": "^0.60.0",
     "rollup-plugin-babel": "^3.0.4",
     "rollup-plugin-commonjs": "^9.1.0",
     "rollup-plugin-flow": "^1.1.1",
@@ -93,5 +93,8 @@
   "collective": {
     "type": "opencollective",
     "url": "https://opencollective.com/final-form"
+  },
+  "dependencies": {
+    "react-lifecycles-compat": "^3.0.4"
   }
 }

--- a/src/Field.js
+++ b/src/Field.js
@@ -79,7 +79,7 @@ export default class Field extends React.Component<Props, State> {
 
   notify = (state: FieldState) => this.setState({ state })
 
-  componentWillReceiveProps(nextProps: Props) {
+  UNSAFE_componentWillReceiveProps(nextProps: Props) {
     const { name, subscription } = nextProps
     if (
       this.props.name !== name ||

--- a/src/FormSpy.js
+++ b/src/FormSpy.js
@@ -67,7 +67,7 @@ export default class FormSpy extends React.Component<Props, State> {
     }
   }
 
-  componentWillReceiveProps(nextProps: Props) {
+  UNSAFE_componentWillReceiveProps(nextProps: Props) {
     const { subscription } = nextProps
     if (
       diffSubscription(

--- a/src/ReactFinalForm.js
+++ b/src/ReactFinalForm.js
@@ -54,25 +54,14 @@ export default class ReactFinalForm extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props)
     const {
-      debug,
-      decorators,
-      initialValues,
-      keepDirtyOnReinitialize,
-      mutators,
-      onSubmit,
+      children,
+      component,
+      render,
       subscription,
-      validate,
-      validateOnBlur
+      decorators,
+      ...rest
     } = props
-    const config: Config = {
-      debug,
-      initialValues,
-      keepDirtyOnReinitialize,
-      mutators,
-      onSubmit,
-      validate,
-      validateOnBlur
-    }
+    const config: Config = rest
     this.mounted = false
     try {
       this.form = createForm(config)
@@ -119,7 +108,7 @@ export default class ReactFinalForm extends React.Component<Props, State> {
     return this.form.submit()
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     if (this.form) {
       this.form.pauseValidation()
     }
@@ -134,7 +123,8 @@ export default class ReactFinalForm extends React.Component<Props, State> {
     }
   }
 
-  componentWillUpdate() {
+  UNSAFE_componentWillUpdate() {
+    // istanbul ignore next
     if (this.form) {
       this.resumeValidation = !this.form.isValidationPaused()
       this.form.pauseValidation()
@@ -142,12 +132,13 @@ export default class ReactFinalForm extends React.Component<Props, State> {
   }
 
   componentDidUpdate() {
+    // istanbul ignore next
     if (this.form && this.resumeValidation) {
       this.form.resumeValidation()
     }
   }
 
-  componentWillReceiveProps(nextProps: Props) {
+  UNSAFE_componentWillReceiveProps(nextProps: Props) {
     if (
       nextProps.initialValues &&
       !shallowEqual(this.props.initialValues, nextProps.initialValues)

--- a/src/ReactFinalForm.test.js
+++ b/src/ReactFinalForm.test.js
@@ -687,5 +687,6 @@ describe('ReactFinalForm', () => {
       />
     )
     expect(spy).not.toHaveBeenCalled()
+    spy.mockRestore()
   })
 })


### PR DESCRIPTION
Also adds `UNSAFE_` prefixes to fix #267.

Includes `react-lifecycles-compat` as described [on the React blog](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#open-source-project-maintainers).