### PR TITLE
Actually use react-lifecycles-compat polyfill

### DIFF
--- a/src/Field.js
+++ b/src/Field.js
@@ -1,5 +1,6 @@
 // @flow
 import * as React from 'react'
+import { polyfill } from 'react-lifecycles-compat'
 import PropTypes from 'prop-types'
 import { fieldSubscriptionItems } from 'final-form'
 import diffSubscription from './diffSubscription'
@@ -22,7 +23,7 @@ type State = {
   state: ?FieldState
 }
 
-export default class Field extends React.Component<Props, State> {
+class Field extends React.Component<Props, State> {
   context: ReactContext
   props: Props
   state: State
@@ -233,3 +234,7 @@ export default class Field extends React.Component<Props, State> {
     )
   }
 }
+
+polyfill(Field)
+
+export default Field

--- a/src/FormSpy.js
+++ b/src/FormSpy.js
@@ -1,5 +1,6 @@
 // @flow
 import * as React from 'react'
+import { polyfill } from 'react-lifecycles-compat'
 import PropTypes from 'prop-types'
 import { formSubscriptionItems } from 'final-form'
 import diffSubscription from './diffSubscription'
@@ -15,7 +16,7 @@ import { all } from './ReactFinalForm'
 
 type State = { state: FormState }
 
-export default class FormSpy extends React.Component<Props, State> {
+class FormSpy extends React.Component<Props, State> {
   context: ReactContext
   props: Props
   state: State
@@ -200,3 +201,7 @@ export default class FormSpy extends React.Component<Props, State> {
 FormSpy.contextTypes = {
   reactFinalForm: PropTypes.object
 }
+
+polyfill(FormSpy)
+
+export default FormSpy

--- a/src/ReactFinalForm.js
+++ b/src/ReactFinalForm.js
@@ -1,5 +1,6 @@
 // @flow
 import * as React from 'react'
+import { polyfill } from 'react-lifecycles-compat'
 import PropTypes from 'prop-types'
 import {
   configOptions,
@@ -38,7 +39,7 @@ type State = {
   state: FormState
 }
 
-export default class ReactFinalForm extends React.Component<Props, State> {
+class ReactFinalForm extends React.Component<Props, State> {
   context: ReactContext
   props: Props
   state: State
@@ -288,3 +289,7 @@ export default class ReactFinalForm extends React.Component<Props, State> {
     )
   }
 }
+
+polyfill(ReactFinalForm)
+
+export default ReactFinalForm


### PR DESCRIPTION
Fixes oversight from #272.

Installed in accordance with [instructions on React Blog](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#open-source-project-maintainers).