### PR TITLE
Don't call setConfig for initialValues

### DIFF
--- a/src/ReactFinalForm.js
+++ b/src/ReactFinalForm.js
@@ -143,7 +143,7 @@ class ReactFinalForm extends React.Component<Props, State> {
       this.form.initialize(this.props.initialValues)
     }
     configOptions.forEach(key => {
-      if (prevProps[key] === this.props[key]) {
+      if (key === 'initialValues' || prevProps[key] === this.props[key]) {
         return
       }
       this.form.setConfig(key, this.props[key])


### PR DESCRIPTION
This fixes a bug where re-rendering a form with a new `initialValues` object would reset all field values, even if the new `initialValues` were shallowly equal to the old ones. See the new test for an example of this.

This did cause a concerning change to another test, which was expecting `validate` to be called twice, but now it's only caused once. I think the latter behavior is actually correct and the test was written to work around this bug, but would appreciate some extra eyes on that test change to confirm.