### PR TITLE
Fix support for nested forms by calling stopPropagation

### DIFF
--- a/src/ReactFinalForm.js
+++ b/src/ReactFinalForm.js
@@ -101,9 +101,15 @@ class ReactFinalForm extends React.Component<Props, State> {
   }
 
   handleSubmit = (event: ?SyntheticEvent<HTMLFormElement>) => {
-    if (event && typeof event.preventDefault === 'function') {
+    if (event) {
       // sometimes not true, e.g. React Native
-      event.preventDefault()
+      if (typeof event.preventDefault === 'function') {
+        event.preventDefault()
+      }
+      if (typeof event.stopPropagation === 'function') {
+        // prevent any outer forms from receiving the event too
+        event.stopPropagation()
+      }
     }
     return this.form.submit()
   }


### PR DESCRIPTION
If you have two nested forms, both forms onSubmit were called because stopPropagation wasn't called. With this fix in place, it looks like nested forms are working properly.

Fixes #276.