### PR TITLE
[ReactFinalForm.js]: Add a test for 100% test coverage

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -8,7 +8,7 @@ We are open to, and grateful for, any contributions made by the community.
 ## Reporting issues and asking questions
 
 Before opening an issue, please search
-the[issue tracker](https://github.com/final-form/react-final-form/issues) to
+the [issue tracker](https://github.com/final-form/react-final-form/issues) to
 make sure your issue hasn’t already been reported.
 
 **We use the issue tracker to keep track of bugs and improvements** to 🏁 React

--- a/src/ReactFinalForm.test.js
+++ b/src/ReactFinalForm.test.js
@@ -202,6 +202,28 @@ describe('ReactFinalForm', () => {
     TestUtils.Simulate.submit(form)
     expect(onSubmit).toHaveBeenCalled()
   })
+  it('does not throw if handleSubmit event preventDefault or stopPropagation are not functions', () => {
+    const onSubmit = jest.fn()
+    const dom = TestUtils.renderIntoDocument(
+      <Form onSubmit={onSubmit}>
+        {({ handleSubmit }) => (
+          <form
+            onSubmit={() => {
+              handleSubmit({
+                preventDefault: undefined,
+                stopPropagation: undefined
+              })
+            }}
+          >
+            <Field name="foo" component="input" />
+          </form>
+        )}
+      </Form>
+    )
+    const form = TestUtils.findRenderedDOMComponentWithTag(dom, 'form')
+    TestUtils.Simulate.submit(form)
+    expect(onSubmit).toHaveBeenCalled()
+  })
   it('should reinitialize when initialValues prop changes', () => {
     const renderInput = jest.fn(({ input }) => <input {...input} />)
     class Container extends React.Component {


### PR DESCRIPTION
The test coverage was so close to 100% 
```
[test] ---------------------|----------|----------|----------|----------|-------------------|
[test] File                 |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
[test] ---------------------|----------|----------|----------|----------|-------------------|
[test] All files            |      100 |    98.97 |      100 |      100 |                   |
[test]  Field.js            |      100 |      100 |      100 |      100 |                   |
[test]  FormSpy.js          |      100 |      100 |      100 |      100 |                   |
[test]  ReactFinalForm.js   |      100 |    95.65 |      100 |      100 |           106,109 |
[test]  diffSubscription.js |      100 |      100 |      100 |      100 |                   |
[test]  getValue.js         |      100 |      100 |      100 |      100 |                   |
[test]  isReactNative.js    |      100 |      100 |      100 |      100 |                   |
[test]  isSyntheticEvent.js |      100 |      100 |      100 |      100 |                   |
[test]  renderComponent.js  |      100 |      100 |      100 |      100 |                   |
[test]  shallowEqual.js     |      100 |      100 |      100 |      100 |                   |
[test] ---------------------|----------|----------|----------|----------|-------------------|
```