### PR TITLE
Migrate to new React Context API

### DIFF
--- a/src/Field.js
+++ b/src/Field.js
@@ -1,17 +1,13 @@
 // @flow
 import * as React from 'react'
-import PropTypes from 'prop-types'
 import { fieldSubscriptionItems } from 'final-form'
 import diffSubscription from './diffSubscription'
 import type { FieldSubscription, FieldState } from 'final-form'
-import type {
-  FieldProps as Props,
-  FieldRenderProps,
-  ReactContext
-} from './types'
+import type { FieldProps as Props, FieldRenderProps } from './types'
 import renderComponent from './renderComponent'
 import isReactNative from './isReactNative'
 import getValue from './getValue'
+import { withReactFinalForm } from './reactFinalFormContext'
 
 const all: FieldSubscription = fieldSubscriptionItems.reduce((result, key) => {
   result[key] = true
@@ -23,32 +19,27 @@ type State = {
 }
 
 class Field extends React.Component<Props, State> {
-  context: ReactContext
   props: Props
   state: State
   unsubscribe: () => void
-
-  static contextTypes = {
-    reactFinalForm: PropTypes.object
-  }
 
   static defaultProps = {
     format: (value: ?any, name: string) => (value === undefined ? '' : value),
     parse: (value: ?any, name: string) => (value === '' ? undefined : value)
   }
 
-  constructor(props: Props, context: ReactContext) {
-    super(props, context)
+  constructor(props: Props) {
+    super(props)
     let initialState
 
     // istanbul ignore next
-    if (process.env.NODE_ENV !== 'production' && !context.reactFinalForm) {
+    if (process.env.NODE_ENV !== 'production' && !this.props.reactFinalForm) {
       console.error(
         'Warning: Field must be used inside of a ReactFinalForm component'
       )
     }
 
-    if (this.context.reactFinalForm) {
+    if (this.props.reactFinalForm) {
       // avoid error, warning will alert developer to their mistake
       this.subscribe(props, (state: FieldState) => {
         if (initialState) {
@@ -65,7 +56,7 @@ class Field extends React.Component<Props, State> {
     { isEqual, name, subscription, validateFields }: Props,
     listener: (state: FieldState) => void
   ) => {
-    this.unsubscribe = this.context.reactFinalForm.registerField(
+    this.unsubscribe = this.props.reactFinalForm.registerField(
       name,
       listener,
       subscription || all,
@@ -89,7 +80,7 @@ class Field extends React.Component<Props, State> {
         fieldSubscriptionItems
       )
     ) {
-      if (this.context.reactFinalForm) {
+      if (this.props.reactFinalForm) {
         // avoid error, warning will alert developer to their mistake
         this.unsubscribe()
         this.subscribe(this.props, this.notify)
@@ -171,6 +162,7 @@ class Field extends React.Component<Props, State> {
       subscription,
       validate,
       validateFields,
+      reactFinalForm,
       value: _value,
       ...rest
     } = this.props
@@ -234,4 +226,4 @@ class Field extends React.Component<Props, State> {
   }
 }
 
-export default Field
+export default withReactFinalForm(Field)

--- a/src/FormSpy.js
+++ b/src/FormSpy.js
@@ -1,38 +1,33 @@
 // @flow
 import * as React from 'react'
-import PropTypes from 'prop-types'
 import { formSubscriptionItems } from 'final-form'
 import diffSubscription from './diffSubscription'
 import renderComponent from './renderComponent'
-import type {
-  FormSpyProps as Props,
-  FormSpyRenderProps,
-  ReactContext
-} from './types'
+import type { FormSpyProps as Props, FormSpyRenderProps } from './types'
 import type { FormState } from 'final-form'
 import isSyntheticEvent from './isSyntheticEvent'
 import { all } from './ReactFinalForm'
+import { withReactFinalForm } from './reactFinalFormContext'
 
 type State = { state: FormState }
 
 class FormSpy extends React.Component<Props, State> {
-  context: ReactContext
   props: Props
   state: State
   unsubscribe: () => void
 
-  constructor(props: Props, context: ReactContext) {
-    super(props, context)
+  constructor(props: Props) {
+    super(props)
     let initialState
 
     // istanbul ignore next
-    if (process.env.NODE_ENV !== 'production' && !context.reactFinalForm) {
+    if (process.env.NODE_ENV !== 'production' && !this.props.reactFinalForm) {
       console.error(
         'Warning: FormSpy must be used inside of a ReactFinalForm component'
       )
     }
 
-    if (this.context.reactFinalForm) {
+    if (this.props.reactFinalForm) {
       // avoid error, warning will alert developer to their mistake
       this.subscribe(props, (state: FormState) => {
         if (initialState) {
@@ -54,7 +49,7 @@ class FormSpy extends React.Component<Props, State> {
     { subscription }: Props,
     listener: (state: FormState) => void
   ) => {
-    this.unsubscribe = this.context.reactFinalForm.subscribe(
+    this.unsubscribe = this.props.reactFinalForm.subscribe(
       listener,
       subscription || all
     )
@@ -76,7 +71,7 @@ class FormSpy extends React.Component<Props, State> {
         formSubscriptionItems
       )
     ) {
-      if (this.context.reactFinalForm) {
+      if (this.props.reactFinalForm) {
         // avoid error, warning will alert developer to their mistake
         this.unsubscribe()
         this.subscribe(this.props, this.notify)
@@ -89,8 +84,7 @@ class FormSpy extends React.Component<Props, State> {
   }
 
   render() {
-    const { onChange, subscription, ...rest } = this.props
-    const { reactFinalForm } = this.context
+    const { onChange, reactFinalForm, ...rest } = this.props
     const renderProps: FormSpyRenderProps = {
       batch:
         reactFinalForm &&
@@ -197,8 +191,4 @@ class FormSpy extends React.Component<Props, State> {
   }
 }
 
-FormSpy.contextTypes = {
-  reactFinalForm: PropTypes.object
-}
-
-export default FormSpy
+export default withReactFinalForm(FormSpy)

--- a/src/ReactFinalForm.js
+++ b/src/ReactFinalForm.js
@@ -1,6 +1,5 @@
 // @flow
 import * as React from 'react'
-import PropTypes from 'prop-types'
 import {
   configOptions,
   createForm,
@@ -14,11 +13,13 @@ import type {
   FormState,
   Unsubscribe
 } from 'final-form'
-import type { FormProps as Props, ReactContext } from './types'
+import type { FormProps as Props } from './types'
 import shallowEqual from './shallowEqual'
 import renderComponent from './renderComponent'
 import isSyntheticEvent from './isSyntheticEvent'
 import type { FormRenderProps } from './types.js.flow'
+import { ReactFinalFormContext } from './reactFinalFormContext'
+
 export const version = '3.6.0'
 
 const versions = {
@@ -39,17 +40,12 @@ type State = {
 }
 
 class ReactFinalForm extends React.Component<Props, State> {
-  context: ReactContext
   props: Props
   state: State
   form: FormApi
   mounted: boolean
   resumeValidation: ?boolean
   unsubscriptions: Unsubscribe[]
-
-  static childContextTypes = {
-    reactFinalForm: PropTypes.object
-  }
 
   constructor(props: Props) {
     super(props)
@@ -84,12 +80,6 @@ class ReactFinalForm extends React.Component<Props, State> {
       decorators.forEach(decorator => {
         this.unsubscriptions.push(decorator(this.form))
       })
-    }
-  }
-
-  getChildContext() {
-    return {
-      reactFinalForm: this.form
     }
   }
 
@@ -281,13 +271,17 @@ class ReactFinalForm extends React.Component<Props, State> {
           return this.form.reset(values)
         })
     }
-    return renderComponent(
-      {
-        ...props,
-        ...renderProps,
-        __versions: versions
-      },
-      'ReactFinalForm'
+    return React.createElement(
+      ReactFinalFormContext.Provider,
+      { value: { reactFinalForm: this.form } },
+      renderComponent(
+        {
+          ...props,
+          ...renderProps,
+          __versions: versions
+        },
+        'ReactFinalForm'
+      )
     )
   }
 }

--- a/src/ReactFinalForm.js
+++ b/src/ReactFinalForm.js
@@ -273,7 +273,7 @@ class ReactFinalForm extends React.Component<Props, State> {
     }
     return React.createElement(
       ReactFinalFormContext.Provider,
-      { value: { reactFinalForm: this.form } },
+      { value: this.form },
       renderComponent(
         {
           ...props,

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -95,3 +95,7 @@ export var Field: React.ComponentType<FieldProps>
 export var Form: React.ComponentType<FormProps>
 export var FormSpy: React.ComponentType<FormSpyProps>
 export var version: string
+
+export function withReactFinalForm<T>(
+  component: React.ComponentType<T>
+): React.ComponentType<T & ReactContext>

--- a/src/index.js
+++ b/src/index.js
@@ -2,3 +2,4 @@
 export { default as Field } from './Field'
 export { default as Form, version } from './ReactFinalForm'
 export { default as FormSpy } from './FormSpy'
+export { withReactFinalForm } from './reactFinalFormContext'

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react'
-import type { FieldProps, FormProps, FormSpyProps } from './types'
+import type { FieldProps, FormProps, FormSpyProps, ReactContext } from './types';
 
 export type {
   FieldProps,
@@ -16,3 +16,5 @@ declare export var Field: React.ComponentType<FieldProps>
 declare export var Form: React.ComponentType<FormProps>
 declare export var FormSpy: React.ComponentType<FormSpyProps>
 declare export var version: string
+
+declare export function withReactFinalForm<T>(component: React.ComponentType<T>): React.ComponentType<T & ReactContext>

--- a/src/reactFinalFormContext.js
+++ b/src/reactFinalFormContext.js
@@ -1,0 +1,19 @@
+import * as React from 'react'
+
+export const ReactFinalFormContext = React.createContext({
+  form: null
+})
+
+export const withReactFinalForm = Component => {
+  return class extends React.Component {
+    render() {
+      return React.createElement(ReactFinalFormContext.Consumer, {
+        children: ({ reactFinalForm }) =>
+          React.createElement(Component, {
+            reactFinalForm,
+            ...this.props
+          })
+      })
+    }
+  }
+}

--- a/src/reactFinalFormContext.js
+++ b/src/reactFinalFormContext.js
@@ -1,14 +1,12 @@
 import * as React from 'react'
 
-export const ReactFinalFormContext = React.createContext({
-  form: null
-})
+export const ReactFinalFormContext = React.createContext(null)
 
 export const withReactFinalForm = Component => {
   return class extends React.Component {
     render() {
       return React.createElement(ReactFinalFormContext.Consumer, {
-        children: ({ reactFinalForm }) =>
+        children: reactFinalForm =>
           React.createElement(Component, {
             reactFinalForm,
             ...this.props

--- a/src/reactFinalFormContext.test.js
+++ b/src/reactFinalFormContext.test.js
@@ -1,0 +1,22 @@
+import React from 'react'
+import TestUtils from 'react-dom/test-utils'
+
+import Form from './ReactFinalForm'
+import { withReactFinalForm } from './reactFinalFormContext'
+
+describe('reactFinalFormContext', () => {
+  it('should pass formApi using HOC', () => {
+    const mockComponent = jest.fn(() => <div />)
+    const render = () => {
+      const BoundComponent = withReactFinalForm(mockComponent)
+      return <BoundComponent />
+    }
+    const formComponent = TestUtils.renderIntoDocument(
+      <Form onSubmit={() => {}} render={render} />
+    )
+    expect(mockComponent).toHaveBeenCalled()
+    expect(mockComponent.mock.calls[0][0].reactFinalForm).toBe(
+      formComponent.form
+    )
+  })
+})

--- a/src/types.js.flow
+++ b/src/types.js.flow
@@ -77,6 +77,7 @@ export type FormProps = {
   RenderableProps<FormRenderProps>
 
 export type FieldProps = {
+  reactFinalForm: FormApi,
   allowNull?: boolean,
   format?: (value: any, name: string) => any,
   formatOnBlur?: boolean,
@@ -92,6 +93,7 @@ export type FieldProps = {
 }
 
 export type FormSpyProps = {
+  reactFinalForm: FormApi,
   onChange?: (formState: FormState) => void,
   subscription?: FormSubscription
 } & RenderableProps<FormSpyRenderProps>


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to 🏁 React Final Form!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create an issue to first discuss any significant new
features.

Please try to keep your pull request focused in scope and avoid including
unrelated commits.

After you have submitted your pull request, we’ll try to get back to you as soon
as possible. We may suggest some changes or improvements.

Please format the code before submitting your pull request by running:

```
npm run precommit
```

https://github.com/final-form/react-final-form/blob/master/.github/CONTRIBUTING.md

-->

I think it is good to migrate to new recommended Context API. There is also some library to integrate like `react-final-form-arrays`. I will also create PRs for them