### PR TITLE
Add scripts folder to NPM package

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "module": "dist/react-final-form.es.js",
   "typings": "dist/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "scripts"
   ],
   "scripts": {
     "start": "nps",


### PR DESCRIPTION
To make the postinstall script work.

Commit 802eb474a82004deadf544a65409c127c048b282 added a reference to scripts/postinstall.js. However, the scripts array in package.json does not include the scripts folder which makes the script not available in the NPM package.

This leads to the following error:
```
$ npm install react-final-form

> react-final-form@3.6.6 postinstall .....\node_modules\react-final-form
> node ./scripts/postinstall.js || exit 0

internal/modules/cjs/loader.js:583
    throw err;
    ^

Error: Cannot find module '.....\node_modules\react-final-form\scripts\postinstall.js'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
    at Function.Module._load (internal/modules/cjs/loader.js:507:25)
    at Function.Module.runMain (internal/modules/cjs/loader.js:742:12)
    at startup (internal/bootstrap/node.js:279:19)
    at bootstrapNodeJSCore (internal/bootstrap/node.js:752:3)
```