### PR TITLE
Fix displayName of context provider HOC

### DIFF
--- a/src/reactFinalFormContext.js
+++ b/src/reactFinalFormContext.js
@@ -2,8 +2,16 @@ import * as React from 'react'
 
 export const ReactFinalFormContext = React.createContext(null)
 
+export const getDisplayName = Component => {
+  const displayName = Component.displayName || Component.name || 'Component'
+
+  return `ReactFinalForm(${displayName})`
+}
+
 export const withReactFinalForm = Component => {
   return class extends React.Component {
+    static displayName = getDisplayName(Component)
+
     render() {
       return React.createElement(ReactFinalFormContext.Consumer, {
         children: reactFinalForm =>

--- a/src/reactFinalFormContext.test.js
+++ b/src/reactFinalFormContext.test.js
@@ -2,9 +2,27 @@ import React from 'react'
 import TestUtils from 'react-dom/test-utils'
 
 import Form from './ReactFinalForm'
-import { withReactFinalForm } from './reactFinalFormContext'
+import { getDisplayName, withReactFinalForm } from './reactFinalFormContext'
 
 describe('reactFinalFormContext', () => {
+  describe('getDisplayName', () => {
+    it('return displayName for Wrapped component with displayName', () => {
+      const Component = { displayName: 'Field' }
+
+      expect(getDisplayName(Component)).toEqual('ReactFinalForm(Field)')
+    })
+
+    it('return displayName for Wrapped component with name', () => {
+      const Component = { name: 'Field' }
+
+      expect(getDisplayName(Component)).toEqual('ReactFinalForm(Field)')
+    })
+
+    it('return FinalForm(Component) by default', () => {
+      expect(getDisplayName({})).toEqual('ReactFinalForm(Component)')
+    })
+  })
+
   it('should pass formApi using HOC', () => {
     const mockComponent = jest.fn(() => <div />)
     const render = () => {


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to 🏁 React Final Form!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create an issue to first discuss any significant new
features.

Please try to keep your pull request focused in scope and avoid including
unrelated commits.

After you have submitted your pull request, we’ll try to get back to you as soon
as possible. We may suggest some changes or improvements.

Please format the code before submitting your pull request by running:

```
npm run precommit
```

https://github.com/final-form/react-final-form/blob/master/.github/CONTRIBUTING.md

-->
Since `4.0.0` the displayName of `Field` and `FormSpy` is broken, what causes some issues, for example with `Jest` snapshot tests (see attached screenshots). This PR fixes the displayName of said components.

Before:
<img width="337" alt="screenshot 2018-11-15 at 21 06 03" src="https://user-images.githubusercontent.com/2379486/48578569-4e7c7180-e91a-11e8-9ee4-fc0f36cbc27c.png">
<img width="352" alt="screenshot 2018-11-15 at 21 06 11" src="https://user-images.githubusercontent.com/2379486/48578570-4e7c7180-e91a-11e8-952b-927c7c5eabe2.png">

After:
<img width="372" alt="screenshot 2018-11-15 at 21 10 30" src="https://user-images.githubusercontent.com/2379486/48578819-f5610d80-e91a-11e8-98d0-56250aafffff.png">
<img width="417" alt="screenshot 2018-11-15 at 21 10 51" src="https://user-images.githubusercontent.com/2379486/48578820-f5610d80-e91a-11e8-8964-c085dd2abc17.png">
