### PR TITLE
Expose react context from index, added typescript tests, prepare for React 16.6

### DIFF
--- a/src/ReactFinalForm.d.test.tsx
+++ b/src/ReactFinalForm.d.test.tsx
@@ -13,28 +13,36 @@ const onSubmit = async (values: any) => {
 }
 
 // context
-function withContext() {
-  return withReactFinalForm((props: {} & ReactContext) => (
+export interface FooWithContextProps {}
+
+const FooWithContext = withReactFinalForm<FooWithContextProps>(
+  (props: FooWithContextProps & ReactContext) => (
     <div>{props.reactFinalForm.blur}</div>
-  ))
+  )
+)
+
+const FooContextConsumer = () => (
+  <ReactFinalFormContext.Consumer>
+    {reactFinalForm => <div>{reactFinalForm.blur}</div>}
+  </ReactFinalFormContext.Consumer>
+)
+// FIXME: uncomment when react-final-form switches to react >=16.6
+class FooStaticContext extends React.Component<{}> {
+  public static contextType = ReactFinalFormContext
+  public render() {
+    return <div>{this.context.blur}</div>
+  }
 }
 
-function contextConsumer() {
+function contextUsage() {
   return (
-    <ReactFinalFormContext.Consumer>
-      {reactFinalForm => <div>{reactFinalForm.blur}</div>}
-    </ReactFinalFormContext.Consumer>
+    <React.Fragment>
+      <FooWithContext />
+      <FooContextConsumer />
+      <FooStaticContext />
+    </React.Fragment>
   )
 }
-// FIXME: uncomment when react-final-form switches to react >=16.6
-// function staticContext() {
-//   class Foo extends React.Component<{}> {
-//     public static contextType = ReactFinalFormContext
-//     public render() {
-//       return <div>{this.context.blur}</div>
-//     }
-//   }
-// }
 
 // basic
 function basic() {

--- a/src/ReactFinalForm.d.test.tsx
+++ b/src/ReactFinalForm.d.test.tsx
@@ -1,10 +1,40 @@
 import * as React from 'react'
-import { Form, Field } from './index'
+import {
+  Form,
+  Field,
+  ReactContext,
+  ReactFinalFormContext,
+  withReactFinalForm
+} from './index'
 import { Mutator } from 'final-form/dist'
 
 const onSubmit = async (values: any) => {
   console.log(values)
 }
+
+// context
+function withContext() {
+  return withReactFinalForm((props: {} & ReactContext) => (
+    <div>{props.reactFinalForm.blur}</div>
+  ))
+}
+
+function contextConsumer() {
+  return (
+    <ReactFinalFormContext.Consumer>
+      {reactFinalForm => <div>{reactFinalForm.blur}</div>}
+    </ReactFinalFormContext.Consumer>
+  )
+}
+// FIXME: uncomment when react-final-form switches to react >=16.6
+// function staticContext() {
+//   class Foo extends React.Component<{}> {
+//     public static contextType = ReactFinalFormContext
+//     public render() {
+//       return <div>{this.context.blur}</div>
+//     }
+//   }
+// }
 
 // basic
 function basic() {

--- a/src/ReactFinalForm.d.test.tsx
+++ b/src/ReactFinalForm.d.test.tsx
@@ -1,14 +1,16 @@
+/* tslint:disable: no-shadowed-variable */
+import { Mutator } from 'final-form/dist'
 import * as React from 'react'
 import {
-  Form,
   Field,
+  Form,
   ReactContext,
   ReactFinalFormContext,
   withReactFinalForm
 } from './index'
-import { Mutator } from 'final-form/dist'
 
 const onSubmit = async (values: any) => {
+  // tslint:disable-next-line no-console
   console.log(values)
 }
 
@@ -26,6 +28,7 @@ const FooContextConsumer = () => (
     {reactFinalForm => <div>{reactFinalForm.blur}</div>}
   </ReactFinalFormContext.Consumer>
 )
+
 // FIXME: uncomment when react-final-form switches to react >=16.6
 class FooStaticContext extends React.Component<{}> {
   public static contextType = ReactFinalFormContext
@@ -99,8 +102,8 @@ function simpleSubscription() {
     <Form
       onSubmit={onSubmit}
       subscription={{
-        submitting: true,
         pristine: true,
+        submitting: true,
         values: true
       }}
     >

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -101,3 +101,5 @@ export var version: string
 export function withReactFinalForm<T>(
   component: React.ComponentType<T>
 ): React.ComponentType<T & ReactContext>
+
+export var ReactFinalFormContext: React.Context<FormApi>

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -99,7 +99,7 @@ export var FormSpy: React.ComponentType<FormSpyProps>
 export var version: string
 
 export function withReactFinalForm<T>(
-  component: React.ComponentType<T>
-): React.ComponentType<T & ReactContext>
+  component: React.ComponentType<T & ReactContext>
+): React.ComponentType<T>
 
 export var ReactFinalFormContext: React.Context<FormApi>

--- a/src/index.js
+++ b/src/index.js
@@ -2,4 +2,7 @@
 export { default as Field } from './Field'
 export { default as Form, version } from './ReactFinalForm'
 export { default as FormSpy } from './FormSpy'
-export { withReactFinalForm } from './reactFinalFormContext'
+export {
+  withReactFinalForm,
+  ReactFinalFormContext
+} from './reactFinalFormContext'

--- a/tslint.json
+++ b/tslint.json
@@ -2,6 +2,9 @@
   "defaultSeverity": "error",
   "extends": ["tslint:recommended"],
   "jsRules": {},
-  "rules": {},
+  "rules": {
+    "interface-name": [true, "never-prefix"],
+    "no-empty-interface": false
+  },
   "rulesDirectory": []
 }


### PR DESCRIPTION
The only current way to use the react context is via the HOC. This exposes it in index and adds typescript tests for all forms of use, including commented test for React 16.6 use.

<!--

👋 Hey, thanks for your interest in contributing to 🏁 React Final Form!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create an issue to first discuss any significant new
features.

Please try to keep your pull request focused in scope and avoid including
unrelated commits.

After you have submitted your pull request, we’ll try to get back to you as soon
as possible. We may suggest some changes or improvements.

Please format the code before submitting your pull request by running:

```
npm run precommit
```

https://github.com/final-form/react-final-form/blob/master/.github/CONTRIBUTING.md

-->
