### PR TITLE
Updated material-ui demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ const MyForm = () => (
   - [Hybrid Synchronous/Asynchronous Record-Level Validation](#hybrid-synchronousasynchronous-record-level-validation)
   - [Submission Errors](#submission-errors)
   - [Third Party Components](#third-party-components)
-  - [Material-UI 1.0](#material-ui-10)
+  - [Material-UI 3.0](#material-ui-30)
   - [💥 Performance Optimization Through Subscriptions 💥](#-performance-optimization-through-subscriptions-)
   - [Independent Error Component](#independent-error-component)
   - [Loading and Initializing Values](#loading-and-initializing-values)
@@ -282,9 +282,9 @@ Demonstrates how easy it is to use third party input components. All the third
 party component really needs is `value` and `onChange`, but more complex
 components can accept things like errors.
 
-### [Material-UI 1.0](https://codesandbox.io/s/2z5y03y81r)
+### [Material-UI 3.0](https://codesandbox.io/s/2z5y03y81r)
 
-Demonstrates how to use Material-UI 1.0 input components.
+Demonstrates how to use Material-UI 3.0 input components.
 
 ### 💥 [Performance Optimization Through Subscriptions](https://codesandbox.io/s/32r824vxy1) 💥
 


### PR DESCRIPTION
The updated codesandbox can be found under https://codesandbox.io/s/3190284lv5. Since @erikras is the owner of the original codesandbox he would have to pull in changes.

- some props were moved from the root to `inputProps`
- `InputProps` -> `inputProps` for the selection controls
- `!!checked` -> `Boolean(checked)` (clearer intent)

Closes #362 