### PR TITLE
Add displayName to withReactFinalForm

### DIFF
--- a/src/reactFinalFormContext.js
+++ b/src/reactFinalFormContext.js
@@ -4,6 +4,9 @@ export const ReactFinalFormContext = React.createContext(null)
 
 export const withReactFinalForm = Component => {
   return class extends React.Component {
+    static displayName = `withReactFinalForm(${Component.displayName ||
+      Component.name})`
+
     render() {
       return React.createElement(ReactFinalFormContext.Consumer, {
         children: reactFinalForm =>

--- a/src/reactFinalFormContext.test.js
+++ b/src/reactFinalFormContext.test.js
@@ -19,4 +19,22 @@ describe('reactFinalFormContext', () => {
       formComponent.form
     )
   })
+
+  it('should have a displayName using name from the wrapped component', () => {
+    const MyComponent = () => <div />
+    const BoundComponent = withReactFinalForm(MyComponent)
+
+    expect(BoundComponent.displayName).toEqual(
+      'withReactFinalForm(MyComponent)'
+    )
+  })
+
+  it('should have a displayName using displayName from the wrapped component', () => {
+    const MyComponent = () => <div />
+    MyComponent.displayName = 'CustomName'
+
+    const BoundComponent = withReactFinalForm(MyComponent)
+
+    expect(BoundComponent.displayName).toEqual('withReactFinalForm(CustomName)')
+  })
 })


### PR DESCRIPTION
Fixes this:
![captura de tela 2018-12-19 as 13 09 54](https://user-images.githubusercontent.com/16100409/50230159-47220b00-0393-11e9-8ebb-6a1f116efd0a.png)

More information: [Convention: Wrap the Display Name for Easy Debugging](https://reactjs.org/docs/higher-order-components.html#convention-wrap-the-display-name-for-easy-debugging)