### PR TITLE
Update FieldProps.validate type definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,7 +513,7 @@ that selects all of the items of
 wish to update for. If you don't pass a `subscription` prop, it defaults to
 _all_ of [`FieldState`](https://github.com/final-form/final-form#fieldstate).
 
-#### `validate?: (value: ?any, allValues: Object, meta: FieldState) => ?any`
+#### `validate?: (value: ?any, allValues: Object, meta: ?FieldState) => ?any`
 
 A function that takes the field value, all the values of the form and the `meta` data about the field and
 returns an error if the value is invalid, or `undefined` if the value is valid.

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -5,6 +5,7 @@ import {
   Decorator,
   FormState,
   FormSubscription,
+  FieldState,
   FieldSubscription
 } from 'final-form'
 
@@ -83,7 +84,7 @@ export interface FieldProps extends RenderableProps<FieldRenderProps> {
   name: string
   isEqual?: (a: any, b: any) => boolean
   subscription?: FieldSubscription
-  validate?: (value: any, allValues: object) => any
+  validate?: (value: any, allValues: object, meta?: FieldState) => any
   value?: any
   [otherProp: string]: any
 }


### PR DESCRIPTION
final-form#368 updated the README with the updated prototype for FieldProps.validate.
This change makes the associated update to the Typescript types.