### PR TITLE
Allow passing FormData to Form component

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -69,7 +69,8 @@ export interface RenderableProps<T> {
   render?: (props: T) => React.ReactNode
 }
 
-export interface FormProps extends Config, RenderableProps<FormRenderProps> {
+export interface FormProps<FormData = object> extends 
+  <FormData>, RenderableProps<FormRenderProps> {
   subscription?: FormSubscription
   decorators?: Decorator[]
   initialValuesEqual?: (a?: object, b?: object) => boolean
@@ -94,7 +95,7 @@ export interface FormSpyProps extends RenderableProps<FormSpyRenderProps> {
 }
 
 export var Field: React.ComponentType<FieldProps>
-export var Form: React.ComponentType<FormProps>
+export var Form<FormData = object>: React.ComponentType<FormProps<FormData>>
 export var FormSpy: React.ComponentType<FormSpyProps>
 export var version: string
 


### PR DESCRIPTION
In the existing implementation There is no way to pass FormData to Form component. It would be nice to allow passing it to config when invoking component.

<!--

👋 Hey, thanks for your interest in contributing to 🏁 React Final Form!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create an issue to first discuss any significant new
features.

Please try to keep your pull request focused in scope and avoid including
unrelated commits.

After you have submitted your pull request, we’ll try to get back to you as soon
as possible. We may suggest some changes or improvements.

Please format the code before submitting your pull request by running:

```
npm run precommit
```

https://github.com/final-form/react-final-form/blob/master/.github/CONTRIBUTING.md

-->
