### PR TITLE
Add Form component FormData generic typing

### DIFF
--- a/src/ReactFinalForm.d.test.tsx
+++ b/src/ReactFinalForm.d.test.tsx
@@ -116,3 +116,29 @@ function mutated() {
     </Form>
   )
 }
+
+// with typed form data
+
+const typedOnSubmit = (values: { firstName: string }) => {
+  console.log(values)
+}
+
+function withTypedFormData() {
+  return (
+    <Form<{ firstName: string }> onSubmit={typedOnSubmit}>
+      {({ handleSubmit }) => (
+        <form onSubmit={handleSubmit}>
+          <div>
+            <label>First Name</label>
+            <Field
+              name="firstName"
+              component="input"
+              type="text"
+              placeholder="First Name"
+            />
+          </div>
+        </form>
+      )}
+    </Form>
+  )
+}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -69,7 +69,9 @@ export interface RenderableProps<T> {
   render?: (props: T) => React.ReactNode
 }
 
-export interface FormProps extends Config, RenderableProps<FormRenderProps> {
+export interface FormProps<FormData = object>
+  extends Config<FormData>,
+    RenderableProps<FormRenderProps> {
   subscription?: FormSubscription
   decorators?: Decorator[]
   initialValuesEqual?: (a?: object, b?: object) => boolean
@@ -94,7 +96,9 @@ export interface FormSpyProps extends RenderableProps<FormSpyRenderProps> {
 }
 
 export var Field: React.ComponentType<FieldProps>
-export var Form: React.ComponentType<FormProps>
+export class Form<FormData = object> extends React.Component<
+  FormProps<FormData>
+> {}
 export var FormSpy: React.ComponentType<FormSpyProps>
 export var version: string
 


### PR DESCRIPTION
In TypeScript you can use generic syntax inside of JSX code to allow typing components.
`react-final-form` exposes a way to type `Config` `FormData` through `createForm` but there is no way to access it in `react-final-form`.

This pull request exposes the possibility to pass `FormData` typing to `Form` component.

I've also added typings tests for that.

<!--

👋 Hey, thanks for your interest in contributing to 🏁 React Final Form!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create an issue to first discuss any significant new
features.

Please try to keep your pull request focused in scope and avoid including
unrelated commits.

After you have submitted your pull request, we’ll try to get back to you as soon
as possible. We may suggest some changes or improvements.

Please format the code before submitting your pull request by running:

```
npm run precommit
```

https://github.com/final-form/react-final-form/blob/master/.github/CONTRIBUTING.md

-->
