### PR TITLE
re-write to solely use commit-phase lifecycle methods

### DIFF
--- a/src/Field.test.js
+++ b/src/Field.test.js
@@ -27,6 +27,7 @@ describe('Field', () => {
           <Form
             onSubmit={onSubmitMock}
             initialValues={{ dog: 'Odie', cat: 'Garfield' }}
+            subscription={{}}
           >
             {() => (
               <form>
@@ -108,7 +109,7 @@ describe('Field', () => {
       <Form onSubmit={onSubmitMock} render={render} />
     )
     expect(render).toHaveBeenCalled()
-    expect(render).toHaveBeenCalledTimes(1)
+    expect(render).toHaveBeenCalledTimes(2) // Once for form, and once when field registers
     expect(renderInput).toHaveBeenCalled()
     expect(renderInput).toHaveBeenCalledTimes(1)
   })
@@ -154,28 +155,28 @@ describe('Field', () => {
     )
 
     expect(render).toHaveBeenCalled()
-    expect(render).toHaveBeenCalledTimes(1)
-    expect(render.mock.calls[0][0].active).toBeUndefined()
-    expect(render.mock.calls[0][0].values.foo).toBeUndefined()
+    expect(render).toHaveBeenCalledTimes(2)
+    expect(render.mock.calls[1][0].active).toBeUndefined()
+    expect(render.mock.calls[1][0].values.foo).toBeUndefined()
 
     const input = TestUtils.findRenderedDOMComponentWithTag(dom, 'input')
     TestUtils.Simulate.focus(input)
 
-    expect(render).toHaveBeenCalledTimes(2)
-    expect(render.mock.calls[1][0].active).toBe('foo')
-    expect(render.mock.calls[1][0].values.foo).toBeUndefined()
+    expect(render).toHaveBeenCalledTimes(3)
+    expect(render.mock.calls[2][0].active).toBe('foo')
+    expect(render.mock.calls[2][0].values.foo).toBeUndefined()
 
     TestUtils.Simulate.change(input, { target: { value: 'bar' } })
 
-    expect(render).toHaveBeenCalledTimes(3)
-    expect(render.mock.calls[2][0].active).toBe('foo')
-    expect(render.mock.calls[2][0].values.foo).toBe('bar')
+    expect(render).toHaveBeenCalledTimes(4)
+    expect(render.mock.calls[3][0].active).toBe('foo')
+    expect(render.mock.calls[3][0].values.foo).toBe('bar')
 
     TestUtils.Simulate.blur(input)
 
-    expect(render).toHaveBeenCalledTimes(4)
-    expect(render.mock.calls[3][0].active).toBeUndefined()
-    expect(render.mock.calls[3][0].values.foo).toBe('bar')
+    expect(render).toHaveBeenCalledTimes(5)
+    expect(render.mock.calls[4][0].active).toBeUndefined()
+    expect(render.mock.calls[4][0].values.foo).toBe('bar')
   })
 
   it("should convert '' to undefined on change", () => {
@@ -191,20 +192,20 @@ describe('Field', () => {
     )
 
     expect(render).toHaveBeenCalled()
-    expect(render).toHaveBeenCalledTimes(1)
-    expect(render.mock.calls[0][0].values.foo).toBeUndefined()
+    expect(render).toHaveBeenCalledTimes(2)
+    expect(render.mock.calls[1][0].values.foo).toBeUndefined()
 
     const input = TestUtils.findRenderedDOMComponentWithTag(dom, 'input')
 
     TestUtils.Simulate.change(input, { target: { value: 'bar' } })
 
-    expect(render).toHaveBeenCalledTimes(2)
-    expect(render.mock.calls[1][0].values.foo).toBe('bar')
+    expect(render).toHaveBeenCalledTimes(3)
+    expect(render.mock.calls[2][0].values.foo).toBe('bar')
 
     TestUtils.Simulate.change(input, { target: { value: '' } })
 
-    expect(render).toHaveBeenCalledTimes(3)
-    expect(render.mock.calls[2][0].values.foo).toBeUndefined()
+    expect(render).toHaveBeenCalledTimes(4)
+    expect(render.mock.calls[3][0].values.foo).toBeUndefined()
   })
 
   it('should accept a null parse prop to preserve empty strings', () => {
@@ -220,24 +221,26 @@ describe('Field', () => {
     )
 
     expect(render).toHaveBeenCalled()
-    expect(render).toHaveBeenCalledTimes(1)
-    expect(render.mock.calls[0][0].values.foo).toBeUndefined()
+    expect(render).toHaveBeenCalledTimes(2)
+    expect(render.mock.calls[1][0].values.foo).toBeUndefined()
 
     const input = TestUtils.findRenderedDOMComponentWithTag(dom, 'input')
 
     TestUtils.Simulate.change(input, { target: { value: '' } })
 
-    expect(render).toHaveBeenCalledTimes(2)
-    expect(render.mock.calls[1][0].values.foo).toBe('')
+    expect(render).toHaveBeenCalledTimes(3)
+    expect(render.mock.calls[2][0].values.foo).toBe('')
 
     TestUtils.Simulate.change(input, { target: { value: 'abc' } })
 
-    expect(render).toHaveBeenCalledTimes(3)
-    expect(render.mock.calls[2][0].values.foo).toBe('abc')
+    expect(render).toHaveBeenCalledTimes(4)
+    expect(render.mock.calls[3][0].values.foo).toBe('abc')
   })
 
   it('should accept a format function prop', () => {
-    const format = jest.fn((value, name) => `format.${value}`)
+    const format = jest.fn((value, name) => {
+      return `format.${value}`
+    })
     const renderInput = jest.fn(({ input }) => <input {...input} />)
     const render = jest.fn(() => (
       <form>
@@ -250,7 +253,7 @@ describe('Field', () => {
     )
 
     expect(render).toHaveBeenCalled()
-    expect(render).toHaveBeenCalledTimes(1)
+    expect(render).toHaveBeenCalledTimes(2)
     expect(render.mock.calls[0][0].values.foo).toBeUndefined()
 
     expect(format).toHaveBeenCalled()
@@ -327,7 +330,7 @@ describe('Field', () => {
     )
 
     expect(render).toHaveBeenCalled()
-    expect(render).toHaveBeenCalledTimes(1)
+    expect(render).toHaveBeenCalledTimes(2) // Once for form, and once when field registers
     expect(render.mock.calls[0][0].values.foo).toBeUndefined()
 
     expect(renderInput).toHaveBeenCalled()
@@ -404,19 +407,18 @@ describe('Field', () => {
     )
 
     expect(render).toHaveBeenCalled()
-    // called twice due to field registration adding touched and visited values
-    expect(render).toHaveBeenCalledTimes(1)
-    expect(render.mock.calls[0][0].values.foo).toBeUndefined()
+    expect(render).toHaveBeenCalledTimes(2) // Once for form, and once when field registers
+    expect(render.mock.calls[1][0].values.foo).toBeUndefined()
 
     renderInput.mock.calls[0][0].input.onChange('bar')
 
-    expect(render).toHaveBeenCalledTimes(2)
-    expect(render.mock.calls[1][0].values.foo).toBe('bar')
+    expect(render).toHaveBeenCalledTimes(3)
+    expect(render.mock.calls[2][0].values.foo).toBe('bar')
 
     renderInput.mock.calls[0][0].input.onChange(null)
 
-    expect(render).toHaveBeenCalledTimes(3)
-    expect(render.mock.calls[2][0].values.foo).toBe(null)
+    expect(render).toHaveBeenCalledTimes(4)
+    expect(render.mock.calls[3][0].values.foo).toBe(null)
   })
 
   it('should not let validate prop bleed through', () => {
@@ -434,9 +436,8 @@ describe('Field', () => {
     )
 
     expect(input).toHaveBeenCalled()
-    // called twice due to field registration adding touched and visited values
-    expect(input).toHaveBeenCalledTimes(2)
-    expect(input.mock.calls[1][0].validate).toBeUndefined()
+    expect(input).toHaveBeenCalledTimes(1)
+    expect(input.mock.calls[0][0].validate).toBeUndefined()
   })
 
   it('should not let subscription prop bleed through', () => {
@@ -453,7 +454,6 @@ describe('Field', () => {
     )
 
     expect(input).toHaveBeenCalled()
-    // called twice due to field registration adding touched and visited values
     expect(input).toHaveBeenCalledTimes(1)
     expect(input.mock.calls[0][0].subscription).toBeUndefined()
   })
@@ -464,7 +464,9 @@ describe('Field', () => {
     const requiredUppercase = value =>
       !value
         ? 'Required'
-        : value.toUpperCase() === value ? undefined : 'Must be uppercase'
+        : value.toUpperCase() === value
+        ? undefined
+        : 'Must be uppercase'
     class FieldsContainer extends React.Component {
       state = { uppercase: false }
 
@@ -492,31 +494,32 @@ describe('Field', () => {
     )
 
     expect(input).toHaveBeenCalled()
-    // called twice due to field registration adding touched and visited values
-    expect(input).toHaveBeenCalledTimes(2)
-    expect(input.mock.calls[1][0].meta.error).toBe('Required')
+    expect(input).toHaveBeenCalledTimes(1)
+    expect(input.mock.calls[0][0].meta.error).toBe('Required')
 
-    const { input: { onChange } } = input.mock.calls[1][0]
+    const {
+      input: { onChange }
+    } = input.mock.calls[0][0]
 
     onChange('hi')
 
     // valid now
-    expect(input).toHaveBeenCalledTimes(4)
-    expect(input.mock.calls[3][0].meta.error).toBeUndefined()
+    expect(input).toHaveBeenCalledTimes(3)
+    expect(input.mock.calls[2][0].meta.error).toBeUndefined()
 
     // toggle rules
     const button = TestUtils.findRenderedDOMComponentWithTag(dom, 'button')
     TestUtils.Simulate.click(button)
 
     // props changed, but still valid. doesn't update until next time validation is run
-    expect(input).toHaveBeenCalledTimes(5)
-    expect(input.mock.calls[4][0].meta.error).toBeUndefined()
+    expect(input).toHaveBeenCalledTimes(4)
+    expect(input.mock.calls[3][0].meta.error).toBeUndefined()
 
     onChange('his')
 
     // invalid now
-    expect(input).toHaveBeenCalledTimes(7)
-    expect(input.mock.calls[6][0].meta.error).toBe('Must be uppercase')
+    expect(input).toHaveBeenCalledTimes(6)
+    expect(input.mock.calls[5][0].meta.error).toBe('Must be uppercase')
   })
 
   it('should render checkboxes with checked prop', () => {
@@ -535,7 +538,7 @@ describe('Field', () => {
     )
 
     expect(render).toHaveBeenCalled()
-    expect(render).toHaveBeenCalledTimes(1)
+    expect(render).toHaveBeenCalledTimes(2) // Once for form, and once when field registers
     expect(render.mock.calls[0][0].values.foo).toBe(true)
 
     const input = TestUtils.findRenderedDOMComponentWithTag(dom, 'input')
@@ -559,7 +562,7 @@ describe('Field', () => {
     )
 
     expect(render).toHaveBeenCalled()
-    expect(render).toHaveBeenCalledTimes(1)
+    expect(render).toHaveBeenCalledTimes(2) // Once for form, and once when fields register
     expect(render.mock.calls[0][0].values.foo).toEqual(['a', 'b', 'c'])
 
     const inputs = TestUtils.scryRenderedDOMComponentsWithTag(dom, 'input')
@@ -586,7 +589,7 @@ describe('Field', () => {
     )
 
     expect(render).toHaveBeenCalled()
-    expect(render).toHaveBeenCalledTimes(1)
+    expect(render).toHaveBeenCalledTimes(2) // Once for form, and once when fields register
     expect(render.mock.calls[0][0].values.foo).toEqual(['a', 'b', 'c'])
 
     expect(checkboxA).toHaveBeenCalled()
@@ -615,7 +618,7 @@ describe('Field', () => {
     )
 
     expect(render).toHaveBeenCalled()
-    expect(render).toHaveBeenCalledTimes(1)
+    expect(render).toHaveBeenCalledTimes(2) // Once for form, and once when fields register
     expect(render.mock.calls[0][0].values.foo).toBe('Bar')
 
     const [barInput, bazInput] = TestUtils.scryRenderedDOMComponentsWithTag(

--- a/src/FormSpy.test.js
+++ b/src/FormSpy.test.js
@@ -5,14 +5,6 @@ import Field from './Field'
 import FormSpy from './FormSpy'
 
 const onSubmitMock = () => {}
-const hasFormApi = props => {
-  expect(typeof props.batch).toBe('function')
-  expect(typeof props.blur).toBe('function')
-  expect(typeof props.change).toBe('function')
-  expect(typeof props.focus).toBe('function')
-  expect(typeof props.initialize).toBe('function')
-  expect(typeof props.reset).toBe('function')
-}
 
 describe('FormSpy', () => {
   it('should warn error if not used inside a form', () => {
@@ -41,7 +33,6 @@ describe('FormSpy', () => {
     )
     expect(render).toHaveBeenCalled()
     expect(render).toHaveBeenCalledTimes(1)
-    hasFormApi(render.mock.calls[0][0])
     expect(render.mock.calls[0][0].dirty).toBe(false)
     expect(render.mock.calls[0][0].errors).toEqual({})
     expect(render.mock.calls[0][0].invalid).toBe(false)
@@ -59,7 +50,6 @@ describe('FormSpy', () => {
     renderInput.mock.calls[0][0].input.onChange('bar')
 
     expect(render).toHaveBeenCalledTimes(3)
-    hasFormApi(render.mock.calls[2][0])
     expect(render.mock.calls[2][0].dirty).toBe(true)
     expect(render.mock.calls[2][0].errors).toEqual({})
     expect(render.mock.calls[2][0].invalid).toBe(false)
@@ -107,7 +97,6 @@ describe('FormSpy', () => {
     const dom = TestUtils.renderIntoDocument(<Container />)
     expect(render).toHaveBeenCalled()
     expect(render).toHaveBeenCalledTimes(1)
-    hasFormApi(render.mock.calls[0][0])
     expect(render.mock.calls[0][0].dirty).toBeUndefined()
     expect(render.mock.calls[0][0].errors).toBeUndefined()
     expect(render.mock.calls[0][0].invalid).toBeUndefined()
@@ -127,7 +116,6 @@ describe('FormSpy', () => {
 
     // one for new prop, and again after reregistering
     expect(render).toHaveBeenCalledTimes(3)
-    hasFormApi(render.mock.calls[2][0])
     expect(render.mock.calls[2][0].dirty).toBe(false)
     expect(render.mock.calls[2][0].errors).toBeUndefined()
     expect(render.mock.calls[2][0].invalid).toBeUndefined()
@@ -158,7 +146,6 @@ describe('FormSpy', () => {
     )
     expect(render).toHaveBeenCalled()
     expect(render).toHaveBeenCalledTimes(1)
-    hasFormApi(render.mock.calls[0][0])
     expect(render.mock.calls[0][0].dirty).toBe(false)
     expect(render.mock.calls[0][0].errors).toBeUndefined()
     expect(render.mock.calls[0][0].invalid).toBeUndefined()
@@ -177,7 +164,6 @@ describe('FormSpy', () => {
 
     // once because whole form rerendered, and again because state changed
     expect(render).toHaveBeenCalledTimes(3)
-    hasFormApi(render.mock.calls[2][0])
     expect(render.mock.calls[2][0].dirty).toBe(true)
     expect(render.mock.calls[2][0].errors).toBeUndefined()
     expect(render.mock.calls[2][0].invalid).toBeUndefined()
@@ -415,76 +401,5 @@ describe('FormSpy', () => {
     expect(onChange).toHaveBeenCalled()
     expect(onChange).toHaveBeenCalledTimes(1)
     expect(render).not.toHaveBeenCalled()
-  })
-
-  const deprecatedFns = {
-    // map from name to args
-    batch: [() => {}],
-    blur: ['foo'],
-    change: ['foo', 'bar'],
-    focus: [],
-    initialize: [{ foo: 'bar' }],
-    reset: []
-  }
-
-  Object.keys(deprecatedFns).forEach(key => {
-    it(`should warn if deprecated function props.${key}() is called`, async () => {
-      const spy = jest
-        .spyOn(global.console, 'error')
-        .mockImplementation(() => {})
-      const dom = TestUtils.renderIntoDocument(
-        <Form onSubmit={onSubmitMock}>
-          {() => (
-            <FormSpy>
-              {props => (
-                <button
-                  onClick={() => {
-                    expect(spy).not.toHaveBeenCalled()
-                    props[key](...deprecatedFns[key])
-                    expect(spy).toHaveBeenCalled()
-                    expect(spy).toHaveBeenCalledTimes(1)
-                    expect(spy).toHaveBeenCalledWith(
-                      `Warning: As of React Final Form v3.3.0, props.${key}() is deprecated and will be removed in the next major version of React Final Form. Use: props.form.${key}() instead. Check your FormSpy render prop.`
-                    )
-                  }}
-                >
-                  Click me, Alice!
-                </button>
-              )}
-            </FormSpy>
-          )}
-        </Form>
-      )
-      const button = TestUtils.findRenderedDOMComponentWithTag(dom, 'button')
-      TestUtils.Simulate.click(button)
-      spy.mockRestore()
-    })
-  })
-
-  it(`should warn if deprecated function props.mutators.whatever() is called`, async () => {
-    const spy = jest.spyOn(global.console, 'error').mockImplementation(() => {})
-    const mutator = jest.fn()
-    TestUtils.renderIntoDocument(
-      <Form onSubmit={onSubmitMock} mutators={{ whatever: mutator }}>
-        {() => (
-          <FormSpy>
-            {props => {
-              expect(spy).not.toHaveBeenCalled()
-              expect(mutator).not.toHaveBeenCalled()
-              props.mutators.whatever()
-              expect(mutator).toHaveBeenCalled()
-              expect(mutator).toHaveBeenCalledTimes(1)
-              expect(spy).toHaveBeenCalled()
-              expect(spy).toHaveBeenCalledTimes(1)
-              expect(spy).toHaveBeenCalledWith(
-                `Warning: As of React Final Form v3.3.0, props.mutators is deprecated and will be removed in the next major version of React Final Form. Use: props.form.mutators instead. Check your FormSpy render prop.`
-              )
-              return <div />
-            }}
-          </FormSpy>
-        )}
-      </Form>
-    )
-    spy.mockRestore()
   })
 })

--- a/src/ReactFinalForm.d.test.tsx
+++ b/src/ReactFinalForm.d.test.tsx
@@ -31,7 +31,7 @@ function basic() {
 function simple() {
   return (
     <Form onSubmit={onSubmit}>
-      {({ handleSubmit, reset, submitting, pristine, values }) => (
+      {({ handleSubmit, submitting, pristine, values, form: { reset } }) => (
         <form onSubmit={handleSubmit}>
           <Field
             name="firstName"
@@ -66,7 +66,7 @@ function simpleSubscription() {
         values: true
       }}
     >
-      {({ handleSubmit, reset, submitting, pristine, values }) => (
+      {({ handleSubmit, submitting, pristine, values, form: { reset } }) => (
         <form onSubmit={handleSubmit}>
           <button
             type="button"
@@ -91,7 +91,9 @@ function mutated() {
     <Form onSubmit={onSubmit} mutators={{ setValue }}>
       {({
         handleSubmit,
-        mutators: { setValue },
+        form: {
+          mutators: { setValue }
+        },
         submitting,
         pristine,
         values

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -12,46 +12,40 @@ export interface ReactContext {
   reactFinalForm: FormApi
 }
 
+export interface FieldRenderInputProps {
+  name: string
+  onBlur: <T>(event?: React.FocusEvent<T>) => void
+  onChange: <T>(event: React.ChangeEvent<T> | any) => void
+  onFocus: <T>(event?: React.FocusEvent<T>) => void
+  value: any
+  checked?: boolean
+}
+
+// TODO: Make a diff of `FieldState` without all the functions
+export interface FieldRenderMetaProp {
+  active: boolean
+  data: object
+  dirty: boolean
+  dirtySinceLastSubmit: boolean
+  error: any
+  initial: any
+  invalid: boolean
+  pristine: boolean
+  submitError: any
+  submitFailed: boolean
+  submitSucceeded: boolean
+  submitting: boolean
+  touched: boolean
+  valid: boolean
+  visited: boolean
+}
+
 export interface FieldRenderProps {
-  input: {
-    name: string
-    onBlur: <T>(event?: React.FocusEvent<T>) => void
-    onChange: <T>(event: React.ChangeEvent<T> | any) => void
-    onFocus: <T>(event?: React.FocusEvent<T>) => void
-    value: any
-    checked?: boolean
-  }
-  meta: Partial<{
-    // TODO: Make a diff of `FieldState` without all the functions
-    active: boolean
-    data: object
-    dirty: boolean
-    dirtySinceLastSubmit: boolean
-    error: any
-    initial: any
-    invalid: boolean
-    pristine: boolean
-    submitError: any
-    submitFailed: boolean
-    submitSucceeded: boolean
-    submitting: boolean
-    touched: boolean
-    valid: boolean
-    visited: boolean
-  }>
+  input: FieldRenderInputProps
+  meta: Partial<FieldRenderMetaProp>
 }
 
-export interface SubsetFormApi {
-  batch: (fn: () => void) => void
-  blur: (name: string) => void
-  change: (name: string, value: any) => void
-  focus: (name: string) => void
-  initialize: (values: object) => void
-  mutators: { [key: string]: Function }
-  reset: () => void
-}
-
-export interface FormRenderProps extends FormState, SubsetFormApi {
+export interface FormRenderProps extends FormState {
   batch: (fn: () => void) => void
   form: FormApi
   handleSubmit: (
@@ -59,7 +53,7 @@ export interface FormRenderProps extends FormState, SubsetFormApi {
   ) => Promise<object | undefined> | undefined
 }
 
-export interface FormSpyRenderProps extends FormState, SubsetFormApi {
+export interface FormSpyRenderProps extends FormState {
   form: FormApi
 }
 

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react'
-import type { FieldProps, FormProps, FormSpyProps, ReactContext } from './types';
+import type { FieldProps, FormProps, FormSpyProps, ReactContext } from './types'
 
 export type {
   FieldProps,
@@ -17,4 +17,6 @@ declare export var Form: React.ComponentType<FormProps>
 declare export var FormSpy: React.ComponentType<FormSpyProps>
 declare export var version: string
 
-declare export function withReactFinalForm<T>(component: React.ComponentType<T>): React.ComponentType<T & ReactContext>
+declare export function withReactFinalForm<T>(
+  component: React.ComponentType<T>
+): React.ComponentType<T & ReactContext>

--- a/src/reactFinalFormContext.js
+++ b/src/reactFinalFormContext.js
@@ -2,16 +2,9 @@ import * as React from 'react'
 
 export const ReactFinalFormContext = React.createContext(null)
 
-export const withReactFinalForm = Component => {
-  return class extends React.Component {
-    render() {
-      return React.createElement(ReactFinalFormContext.Consumer, {
-        children: reactFinalForm =>
-          React.createElement(Component, {
-            reactFinalForm,
-            ...this.props
-          })
-      })
-    }
-  }
+export const withReactFinalForm = Component => props => {
+  return React.createElement(ReactFinalFormContext.Consumer, {
+    children: reactFinalForm =>
+      React.createElement(Component, { reactFinalForm, ...props })
+  })
 }

--- a/src/types.js.flow
+++ b/src/types.js.flow
@@ -1,13 +1,14 @@
 // @flow
 import * as React from 'react'
 import type {
-  FormApi,
   Config,
   Decorator,
-  FormState,
-  FormSubscription,
+  FieldState,
   FieldSubscription,
-  FieldValidator
+  FieldValidator,
+  FormApi,
+  FormState,
+  FormSubscription
 } from 'final-form'
 
 type SupportedInputs = 'input' | 'select' | 'textarea'
@@ -16,54 +17,40 @@ export type ReactContext = {
   reactFinalForm: FormApi
 }
 
-export type FieldRenderProps = {
-  input: {
-    name: string,
-    onBlur: (?SyntheticFocusEvent<*>) => void,
-    onChange: (SyntheticInputEvent<*> | any) => void,
-    onFocus: (?SyntheticFocusEvent<*>) => void,
-    value: any,
-    checked?: boolean
-  },
-  meta: {
-    // TODO: Make a diff of `FieldState` without all the functions
-    active?: boolean,
-    data?: Object,
-    dirty?: boolean,
-    dirtySinceLastSubmit?: boolean,
-    error?: any,
-    initial?: boolean,
-    invalid?: boolean,
-    pristine?: boolean,
-    submitError?: any,
-    submitFailed?: boolean,
-    submitSucceeded?: boolean,
-    submitting?: boolean,
-    touched?: boolean,
-    valid?: boolean,
-    visited?: boolean
-  }
+export type FieldRenderInputProp = {
+  name: $PropertyType<FieldState, 'name'>,
+  onBlur: (?SyntheticFocusEvent<*>) => void,
+  onChange: (SyntheticInputEvent<*> | any) => void,
+  onFocus: (?SyntheticFocusEvent<*>) => void,
+  value: $PropertyType<FieldState, 'value'>,
+  checked?: boolean
 }
 
-export type SubsetFormApi = {
-  blur: (name: string) => void,
-  change: (name: string, value: any) => void,
-  focus: (name: string) => void,
-  initialize: (values: Object) => void,
-  mutators: { [string]: Function },
-  reset: () => void
-} & FormState
+export type FieldRenderMetaProp = $Diff<
+  FieldState,
+  {
+    name: $PropertyType<FieldState, 'name'>,
+    value: $PropertyType<FieldState, 'value'>,
+    length: $PropertyType<FieldState, 'length'>,
+    change: $PropertyType<FieldState, 'change'>,
+    blur: $PropertyType<FieldState, 'blur'>,
+    focus: $PropertyType<FieldState, 'focus'>
+  }
+>
+
+export type FieldRenderProps = {
+  input: FieldRenderInputProp,
+  meta: FieldRenderMetaProp
+}
 
 export type FormRenderProps = {
   handleSubmit: (?SyntheticEvent<HTMLFormElement>) => ?Promise<?Object>,
   form: FormApi
-} & FormState &
-  SubsetFormApi
+} & FormState
 
 export type FormSpyRenderProps = {
   form: FormApi
-} & SubsetFormApi &
-  FormState
+} & FormState
 
 export type RenderableProps<T> = {
   component?: React.ComponentType<*> | SupportedInputs,


### PR DESCRIPTION
### Related Issue: #411

## "Discussion" (and potential implementation) PR as to how best to make `react-final-form`:
- `React` 16.(9?)+ compliant
- Work properly with `React.StrictMode` (already out)
- Work properly with `React.ConcurrentMode` (~Q2 2019)
(dates taken from https://reactjs.org/blog/2018/11/27/react-16-roadmap.html)


### About `React.StrictMode` and `React.ConcurrentMode`
`React.StrictMode` runs only in `NODE_ENV === 'development'`, and calls all render-phase lifecycle methods **twice** - This includes the `constructor`. This is because these lifecycles should be pure, as `React`'s "Concurrent Mode" makes no guarantees that render-phase methods are only called once. In fact, they can be called as many times as needed, and may never be committed at all.


### About the `ReactFinalForm` double-render (or how I learned to love the `return null`)

I'm using a double-render trick with `componentDidMount` to cut out an initial (pointless) final-form-not-ready render, so the flow looks like this:
1. Render-phase lifecycle methods called (twice)
2. `render` returns `null`, as it isn't mounted yet
3. `componentDidMount` called, which sets up the form, does all the initialisation, and calls `setState({ mounted: true });`
4. `render` is called again from the `setState`, and now actually renders the form (with the `final-form` form).

The initial `render` returning null is **not** committed to the DOM, so the user will only see the final result
> You may call setState() immediately in componentDidMount(). It will trigger an extra rendering, but it will happen before the browser updates the screen. This guarantees that even though the render() will be called twice in this case, the user won’t see the intermediate state.
>
> &mdash; _https://reactjs.org/docs/react-component.html#componentdidmount_


### Next steps - Counter-PR

Hopefully within the next week or two, I'll raise a counter-PR with another way to do it, by ensuring the render-phase lifecycle methods (primarily, the `constructor`) can handle being called twice, but only do anything if `this.form` hasn't already been constructed for that class instance. I will still have to remove deprecated lifecycle methods, though (e.g. `componentWillMount`)