### PR TITLE
Add Typescript typings for the third argument of the `validate` function

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -12,6 +12,25 @@ export interface ReactContext {
   reactFinalForm: FormApi
 }
 
+export type FieldPlaneState = Partial<{
+  // TODO: Make a diff of `FieldState` without all the functions
+  active: boolean
+  data: object
+  dirty: boolean
+  dirtySinceLastSubmit: boolean
+  error: any
+  initial: any
+  invalid: boolean
+  pristine: boolean
+  submitError: any
+  submitFailed: boolean
+  submitSucceeded: boolean
+  submitting: boolean
+  touched: boolean
+  valid: boolean
+  visited: boolean
+}>
+
 export interface FieldRenderProps {
   input: {
     name: string
@@ -21,24 +40,7 @@ export interface FieldRenderProps {
     value: any
     checked?: boolean
   }
-  meta: Partial<{
-    // TODO: Make a diff of `FieldState` without all the functions
-    active: boolean
-    data: object
-    dirty: boolean
-    dirtySinceLastSubmit: boolean
-    error: any
-    initial: any
-    invalid: boolean
-    pristine: boolean
-    submitError: any
-    submitFailed: boolean
-    submitSucceeded: boolean
-    submitting: boolean
-    touched: boolean
-    valid: boolean
-    visited: boolean
-  }>
+  meta: FieldPlaneState
 }
 
 export interface SubsetFormApi {
@@ -83,7 +85,7 @@ export interface FieldProps extends RenderableProps<FieldRenderProps> {
   name: string
   isEqual?: (a: any, b: any) => boolean
   subscription?: FieldSubscription
-  validate?: (value: any, allValues: object) => any
+  validate?: (value: any, allValues: object, meta: FieldPlaneState) => any
   value?: any
   [otherProp: string]: any
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -72,7 +72,7 @@ export interface FieldProps extends RenderableProps<FieldRenderProps> {
   name: string
   isEqual?: (a: any, b: any) => boolean
   subscription?: FieldSubscription
-  validate?: (value: any, allValues: object, meta: FieldPlaneState) => any
+  validate?: (value: any, allValues: object, meta?: FieldPlaneState) => any
   value?: any
   [otherProp: string]: any
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -5,31 +5,18 @@ import {
   Decorator,
   FormState,
   FormSubscription,
-  FieldSubscription
+  FieldSubscription,
+  FieldState
 } from 'final-form'
 
 export interface ReactContext {
   reactFinalForm: FormApi
 }
 
-export type FieldPlaneState = Partial<{
-  // TODO: Make a diff of `FieldState` without all the functions
-  active: boolean
-  data: object
-  dirty: boolean
-  dirtySinceLastSubmit: boolean
-  error: any
-  initial: any
-  invalid: boolean
-  pristine: boolean
-  submitError: any
-  submitFailed: boolean
-  submitSucceeded: boolean
-  submitting: boolean
-  touched: boolean
-  valid: boolean
-  visited: boolean
-}>
+export type FieldPlaneState = Pick<
+  FieldState,
+  Exclude<keyof FieldState, 'blur' | 'change' | 'focus'>
+>
 
 export interface FieldRenderProps {
   input: {


### PR DESCRIPTION
This is where the third argument of the `validate` function has been added: https://github.com/final-form/final-form/pull/125
But no Typescript typings were added.
Fixed.

Also, I've moved `meta` typings into separate `type`, to avoid typings duplication.