### PR TITLE
Fix input.onChange TS type signature

### DIFF
--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -22,7 +22,7 @@ export interface FieldRenderProps<T extends HTMLElement> {
   input: {
     name: string;
     onBlur: (event?: React.FocusEvent<T>) => void;
-    onChange: (event: React.ChangeEvent<T>) => void;
+    onChange: (event: React.ChangeEvent<T> | any) => void;
     onFocus: (event?: React.FocusEvent<T>) => void;
     value: any;
     checked?: boolean;


### PR DESCRIPTION
Hi!

The Flow type signature of `input.onChange` is [`(event: SyntheticInputEvent<*> | any) => void`](https://github.com/final-form/react-final-form/blob/master/src/Field.js#L117) while the TypeScript signature is [`onChange: (event: React.ChangeEvent<T>) => void`](https://github.com/final-form/react-final-form/blob/master/typescript/index.d.ts#L25).

This PR adds the `| any` in the TS definition.
