### PR TITLE
expose form name to field and withReactFinalForm.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-final-form",
-  "version": "4.0.2",
+  "version": "4.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/Field.js
+++ b/src/Field.js
@@ -194,7 +194,8 @@ class Field extends React.Component<Props, State> {
       submitting: otherState.submitting,
       touched: otherState.touched,
       valid: otherState.valid,
-      visited: otherState.visited
+      visited: otherState.visited,
+      formName: reactFinalForm ? reactFinalForm.getFormName() : ''
     }
     if (formatOnBlur) {
       value = Field.defaultProps.format(value, name)

--- a/src/Field.test.js
+++ b/src/Field.test.js
@@ -464,7 +464,9 @@ describe('Field', () => {
     const requiredUppercase = value =>
       !value
         ? 'Required'
-        : value.toUpperCase() === value ? undefined : 'Must be uppercase'
+        : value.toUpperCase() === value
+        ? undefined
+        : 'Must be uppercase'
     class FieldsContainer extends React.Component {
       state = { uppercase: false }
 
@@ -496,7 +498,9 @@ describe('Field', () => {
     expect(input).toHaveBeenCalledTimes(2)
     expect(input.mock.calls[1][0].meta.error).toBe('Required')
 
-    const { input: { onChange } } = input.mock.calls[1][0]
+    const {
+      input: { onChange }
+    } = input.mock.calls[1][0]
 
     onChange('hi')
 
@@ -811,5 +815,36 @@ describe('Field', () => {
     )
 
     spy.mockRestore()
+  })
+
+  it('should render formName in meta', () => {
+    const input = jest.fn(({ input }) => <input {...input} />)
+
+    TestUtils.renderIntoDocument(
+      <Form
+        name="carefullyThoughtOutFormName"
+        onSubmit={onSubmitMock}
+        initialValues={{ foo: 'Bar' }}
+        subscription={{ pristine: true }}
+      >
+        {() => (
+          <form>
+            <Field
+              name="foo"
+              render={input}
+              isEqual={(a, b) =>
+                (a && a.toUpperCase()) === (b && b.toUpperCase())
+              }
+            />
+          </form>
+        )}
+      </Form>
+    )
+
+    expect(input).toHaveBeenCalled()
+    expect(input).toHaveBeenCalledTimes(1)
+    expect(input.mock.calls[0][0].meta.formName).toBe(
+      'carefullyThoughtOutFormName'
+    )
   })
 })

--- a/src/FormSpy.js
+++ b/src/FormSpy.js
@@ -176,7 +176,8 @@ class FormSpy extends React.Component<Props, State> {
             )
           }
           return reactFinalForm.reset(values)
-        })
+        }),
+      formName: reactFinalForm && (() => reactFinalForm.getFormName())
     }
     return onChange
       ? null

--- a/src/ReactFinalForm.js
+++ b/src/ReactFinalForm.js
@@ -177,6 +177,7 @@ class ReactFinalForm extends React.Component<Props, State> {
       subscription,
       validate,
       validateOnBlur,
+      name,
       ...props
     } = this.props
     const renderProps: FormRenderProps = {
@@ -273,7 +274,8 @@ class ReactFinalForm extends React.Component<Props, State> {
             )
           }
           return this.form.reset(values)
-        })
+        }),
+      formName: this.form && (() => this.form.getFormName())
     }
     return React.createElement(
       ReactFinalFormContext.Provider,

--- a/src/reactFinalFormContext.test.js
+++ b/src/reactFinalFormContext.test.js
@@ -36,5 +36,27 @@ describe('reactFinalFormContext', () => {
     expect(mockComponent.mock.calls[0][0].reactFinalForm).toBe(
       formComponent.form
     )
+    console.log(mockComponent.mock.calls[0][0].reactFinalForm.getFormName())
+  })
+  it('should get formName form formApi using HOC', () => {
+    const mockComponent = jest.fn(() => <div />)
+    const render = () => {
+      const BoundComponent = withReactFinalForm(mockComponent)
+      return <BoundComponent />
+    }
+    const formComponent = TestUtils.renderIntoDocument(
+      <Form
+        onSubmit={() => {}}
+        render={render}
+        name="carefullyThoughtOutFormName"
+      />
+    )
+    expect(mockComponent).toHaveBeenCalled()
+    expect(mockComponent.mock.calls[0][0].reactFinalForm).toBe(
+      formComponent.form
+    )
+    expect(mockComponent.mock.calls[0][0].reactFinalForm.getFormName()).toBe(
+      'carefullyThoughtOutFormName'
+    )
   })
 })

--- a/src/types.js.flow
+++ b/src/types.js.flow
@@ -42,7 +42,8 @@ export type FieldRenderProps = {
     submitting?: boolean,
     touched?: boolean,
     valid?: boolean,
-    visited?: boolean
+    visited?: boolean,
+    formName?: ?string
   }
 }
 


### PR DESCRIPTION
dependend on pull request in https://github.com/final-form/final-form/pull/204 in final-form

I would like to add support for name property/attribute to final-form since form name is a default property/attribute, its handy to get some context when dynamically and re-using custom field components.
This is part one of a two part pull request the other one will be for react-final-form.