### PR TITLE
[Typescript] Fix input.onChange signature

### DIFF
--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -22,7 +22,7 @@ export interface FieldRenderProps<T extends HTMLElement> {
   input: {
     name: string;
     onBlur: (event?: React.FocusEvent<T>) => void;
-    onChange: (event: React.ChangeEvent<T>) => void;
+    onChange: (event: React.ChangeEvent<T> | any) => void;
     onFocus: (event?: React.FocusEvent<T>) => void;
     value: any;
     checked?: boolean;


### PR DESCRIPTION
`input.onChange` accepts events but also directly values as per the documentation.
The typescript definition was not in sync with this behaviors
