### PR TITLE
Use updated value for `formatOnBlur` format func

### DIFF
--- a/src/Field.test.js
+++ b/src/Field.test.js
@@ -278,6 +278,43 @@ describe('Field', () => {
     expect(getByTestId('name').value).toBe('ERIKRAS')
   })
 
+  it('should `formatOnBlur` most updated value', () => {
+    const format = jest.fn(value => (value ? value.trim() : ''))
+    const handleBlur = event => {
+      fireEvent.change(getByTestId('name'), {
+        target: { value: event.target.value.toUpperCase() }
+      })
+    }
+    const { getByTestId } = render(
+      <Form onSubmit={onSubmitMock} subscription={{ values: true }}>
+        {() => (
+          <form>
+            <Field name="name" format={format} formatOnBlur>
+              {({ input }) => (
+                <input
+                  {...input}
+                  data-testid="name"
+                  onBlur={e => {
+                    handleBlur(e)
+                    input.onBlur(e)
+                  }}
+                />
+              )}
+            </Field>
+          </form>
+        )}
+      </Form>
+    )
+    const inputText = '   erikras'
+    fireEvent.focus(getByTestId('name'))
+    expect(getByTestId('name').value).toBe('')
+    fireEvent.change(getByTestId('name'), { target: { value: inputText } })
+    expect(getByTestId('name').value).toBe(inputText)
+    fireEvent.blur(getByTestId('name'))
+    expect(format.mock.calls[0][0]).toBe(inputText.toUpperCase())
+    expect(getByTestId('name').value).toBe(inputText.trim().toUpperCase())
+  })
+
   it('should not format value at all when formatOnBlur and render prop', () => {
     const format = jest.fn(value => (value ? value.toUpperCase() : ''))
     render(

--- a/src/Field.test.js
+++ b/src/Field.test.js
@@ -280,11 +280,6 @@ describe('Field', () => {
 
   it('should `formatOnBlur` most updated value', () => {
     const format = jest.fn(value => (value ? value.trim() : ''))
-    const handleBlur = event => {
-      fireEvent.change(getByTestId('name'), {
-        target: { value: event.target.value.toUpperCase() }
-      })
-    }
     const { getByTestId } = render(
       <Form onSubmit={onSubmitMock} subscription={{ values: true }}>
         {() => (
@@ -295,7 +290,7 @@ describe('Field', () => {
                   {...input}
                   data-testid="name"
                   onBlur={e => {
-                    handleBlur(e)
+                    input.onChange(e.target.value && e.target.value.toUpperCase())
                     input.onBlur(e)
                   }}
                 />

--- a/src/useField.js
+++ b/src/useField.js
@@ -108,7 +108,10 @@ const useField = (
       (event: ?SyntheticFocusEvent<*>) => {
         state.blur()
         if (formatOnBlur) {
-          state.change(format(state.value, state.name))
+          const fieldState = form.getFieldState(state.name)
+          state.change(
+            format(fieldState ? fieldState.value : state.value, state.name)
+          )
         }
       },
       // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
When there's a `format` function that's called `onBlur` it passes the
current value from state to that `format` function.
https://github.com/final-form/react-final-form/blob/41d24d6db197a5eec73e52623a267f98bb2337dc/src/Field.js#L113

This causes that when the field's `onChange` is called from within the `onBlur`
the `formatOnBlur` function is not getting the updated value.
Rather, it has the previous value passed to it, so when
formatting the value it ends up formatting and returning the previous value.

This pr changes to pass the current updated value from `props.reactFinalForm`'s state,
to the format func so it always gets the current value.
[See Demo](https://codesandbox.io/s/j2j8w0nlp5)