### PR TITLE
Bug Fix: Add state.change to useField's onChange dependencies.

### DIFF
--- a/src/useField.js
+++ b/src/useField.js
@@ -140,7 +140,7 @@ const useField = (
         state.change(parse ? parse(value, name) : value)
       },
       // eslint-disable-next-line react-hooks/exhaustive-deps
-      [_value, name, parse, state.value, type]
+      [_value, name, parse, state.change, state.value, type]
     ),
     onFocus: React.useCallback((event: ?SyntheticFocusEvent<*>) => {
       state.focus()


### PR DESCRIPTION
First off, I love the project and appreciate being able to use it.

In my project I have what may be an unconventional form where the fields that are rendered on the screen depend on what the user selects. The form as well as all the selectable categories are visible at the same time.  I found a problem when I was migrating to version 5.x in my unit tests where once a subset was 'selected' a second time a textarea onChange event no longer updated the fields value. 

I was trying to debug my own code and found no problems so I started playing with the code under the hood and I found that `state.change` was not part of the dependencies of the onChange useCallback. I added it and my test started passing as expected. 

Adding state.change as a dependency is all the pull request does, but if there is a reason that state.change should not be in the dependencies (maybe performance?) then I could work on creating a reproducible example.  