### PR TITLE
add beforeSubmit and afterSubmit to typescript def

### DIFF
--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -72,7 +72,9 @@ export interface FormProps extends Config, RenderableProps<FormRenderProps> {
 }
 
 export interface UseFieldConfig {
+  afterSubmit?: () => void;
   allowNull?: boolean;
+  beforeSubmit?: () => void | boolean;
   defaultValue?: any;
   format?: ((value: any, name: string) => any) | null;
   formatOnBlur?: boolean;


### PR DESCRIPTION
add `afterSubmit` and `beforeSubmit` callbacks to the Typescript definition file.