### PR TITLE
Fix `submitting` state never getting reset

### DIFF
--- a/src/ReactFinalForm.js
+++ b/src/ReactFinalForm.js
@@ -103,7 +103,7 @@ const ReactFinalForm = ({
       unsubscriptions.forEach(unsubscribe => unsubscribe())
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [decorators, flattenedSubscription])
+  }, [decorators, flattenedSubscription, state])
 
   // warn about decorator changes
   // istanbul ignore next


### PR DESCRIPTION
fixes #487

Previously, when it was checking in the subscribe func if state updated https://github.com/final-form/react-final-form/blob/4ca1ce7a7800c08b249219e14740ec2c1ed7e222/src/ReactFinalForm.js#L89  the current state `state` - was always the initial state, bec of js closures.

So, the `submitting` state got set to `true` bec that was different than the initial state but when attempting to set back to false.. it was checking the initial state of `false` with current updated state of `false` and it was equal and therefore did not update and reset state.

Changed to add `state` to the `useEffect` deps so it will rerun the effect, causing it to create a new subscribe func with the updated state.

fixes #492

