### PR TITLE
Update Types to make useField's options optional

### DIFF
--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -102,7 +102,7 @@ export const Form: React.FC<FormProps<object>>;
 export const FormSpy: React.FC<FormSpyProps>;
 export function useField<T extends HTMLElement>(
   name: string,
-  config: UseFieldConfig
+  config?: UseFieldConfig
 ): FieldRenderProps<T>;
 export function useForm(componentName?: string): FormApi;
 export function useFormState(params?: UseFormStateParams): FormState;


### PR DESCRIPTION
`useField` has a [default value](https://github.com/final-form/react-final-form/blob/master/src/useField.js#L39) but the Types do not.

That means `useField('name')` throws an error in TS.

This PR make the options object optional.