### PR TITLE
Fix Flow typings for UseFieldConfig and FieldProps

### DIFF
--- a/src/types.js.flow
+++ b/src/types.js.flow
@@ -75,7 +75,8 @@ export type UseFieldConfig = {
   afterSubmit?: () => void,
   allowNull?: boolean,
   beforeSubmit?: () => void | false,
-  component?: SupportedInputs,
+  children?: $PropertyType<RenderableProps<*>, 'children'>,
+  component?: $PropertyType<RenderableProps<*>, 'component'>,
   defaultValue?: any,
   format?: (value: any, name: string) => any,
   formatOnBlur?: boolean,
@@ -92,9 +93,7 @@ export type UseFieldConfig = {
 
 export type FieldProps = UseFieldConfig & {
   name: string
-} & RenderableProps<FieldRenderProps> & {
-    component?: React.ComponentType<*> | SupportedInputs
-  }
+} & RenderableProps<FieldRenderProps>
 
 export type UseFormStateParams = {
   onChange?: (formState: FormState) => void,


### PR DESCRIPTION
There was a mismatch between the source code and Flow typings which led to the following error:
```js
<Field
  name={name}
  component={SomeCustomInputComponent}
  /* ^^^ Flow error here:
  Cannot create Field element because in property component:
   • Either function [1] is incompatible with string literal
     input [2].
   • Or function [1] is incompatible with string literal
     select [3].
   • Or function [1] is incompatible with string literal
     textarea [4].
  */
/>
```

<!--

👋 Hey, thanks for your interest in contributing to 🏁 React Final Form!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create an issue to first discuss any significant new
features.

Please try to keep your pull request focused in scope and avoid including
unrelated commits.

After you have submitted your pull request, we’ll try to get back to you as soon
as possible. We may suggest some changes or improvements.

Please format the code before submitting your pull request by running:

```
npm run precommit
```

https://github.com/final-form/react-final-form/blob/master/.github/CONTRIBUTING.md

-->
