### PR TITLE
Replace empty object default type with any object

### DIFF
--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -33,6 +33,10 @@ interface FieldInputProps<T extends HTMLElement> {
   multiple?: boolean;
 }
 
+interface AnyObject {
+  [key: string]: any;
+}
+
 export interface FieldRenderProps<T extends HTMLElement> {
   input: FieldInputProps<T>;
   meta: FieldMetaState;
@@ -42,7 +46,7 @@ export interface FormRenderProps<FormValues> extends FormState<FormValues> {
   form: FormApi<FormValues>;
   handleSubmit: (
     event?: React.SyntheticEvent<HTMLFormElement>
-  ) => Promise<object | undefined> | undefined;
+  ) => Promise<AnyObject | undefined> | undefined;
 }
 
 export interface FormSpyRenderProps<FormValues> extends FormState<FormValues> {
@@ -55,13 +59,13 @@ export interface RenderableProps<T> {
   render?: (props: T) => React.ReactNode;
 }
 
-export interface FormProps<FormValues = object>
+export interface FormProps<FormValues = AnyObject>
   extends Config<FormValues>,
     RenderableProps<FormRenderProps<FormValues>> {
   subscription?: FormSubscription;
   decorators?: Decorator[];
   form?: FormApi<FormValues>;
-  initialValuesEqual?: (a?: object, b?: object) => boolean;
+  initialValuesEqual?: (a?: AnyObject, b?: AnyObject) => boolean;
 }
 
 export interface UseFieldConfig {
@@ -89,7 +93,7 @@ export interface FieldProps<T extends HTMLElement>
   [otherProp: string]: any;
 }
 
-export interface UseFormStateParams<FormValues = object> {
+export interface UseFormStateParams<FormValues = AnyObject> {
   onChange?: (formState: FormState<FormValues>) => void;
   subscription?: FormSubscription;
 }
@@ -99,16 +103,16 @@ export interface FormSpyProps<FormValues>
     RenderableProps<FormSpyRenderProps<FormValues>> {}
 
 export const Field: React.FC<FieldProps<any>>;
-export const Form: React.FC<FormProps<object>>;
-export const FormSpy: React.FC<FormSpyProps<object>>;
+export const Form: React.FC<FormProps<AnyObject>>;
+export const FormSpy: React.FC<FormSpyProps<AnyObject>>;
 export function useField<T extends HTMLElement>(
   name: string,
   config?: UseFieldConfig
 ): FieldRenderProps<T>;
-export function useForm<FormValues = object>(
+export function useForm<FormValues = AnyObject>(
   componentName?: string
 ): FormApi<FormValues>;
-export function useFormState<FormValues = object>(
+export function useFormState<FormValues = AnyObject>(
   params?: UseFormStateParams
 ): FormState<FormValues>;
 export function withTypes<FormValues>(): {


### PR DESCRIPTION
By default FormValues is of type `object` which is empty. When accessing a property on the values object, TypeScript raises the following error:

`Property 'myprop' does not exist on type 'object'.ts(2339)`

This PR resolves this issue.

<!--

👋 Hey, thanks for your interest in contributing to 🏁 React Final Form!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create an issue to first discuss any significant new
features.

Please try to keep your pull request focused in scope and avoid including
unrelated commits.

After you have submitted your pull request, we’ll try to get back to you as soon
as possible. We may suggest some changes or improvements.

Please format the code before submitting your pull request by running:

```
npm run precommit
```

https://github.com/final-form/react-final-form/blob/master/.github/CONTRIBUTING.md

-->
