### PR TITLE
Actual return type for the handleSubmit function

### DIFF
--- a/README.md
+++ b/README.md
@@ -787,7 +787,7 @@ as well as:
 
 The 🏁 Final Form [`FormApi`](https://github.com/final-form/final-form#formapi).
 
-#### `handleSubmit: (?SyntheticEvent<HTMLFormElement>) => void`
+#### `handleSubmit: (?SyntheticEvent<HTMLFormElement>) => ?Promise<?Object>`
 
 A function intended for you to give directly to the `<form>` tag: `<form onSubmit={handleSubmit}/>`.
 


### PR DESCRIPTION
Very small pull request that updates the docs to reflect the actual Flow types of `handleSubmit`.

I think some explanation may be added, though. If the function is intended to be passed to the `<form>` element, one might wonder what is the point of returning a promise.

