### PR TITLE
Fixed destroyOnUnregister bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4492,9 +4492,9 @@
       }
     },
     "final-form": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/final-form/-/final-form-4.15.0.tgz",
-      "integrity": "sha512-A7pvzFAZ/mswLfU4pMKnB+otx3ttv8dO6/X+gWqhUSP+EpNsMenY88PHuGNJ9bIkhYcwF1ErXB8b2E2EMHKBLg==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/final-form/-/final-form-4.16.0.tgz",
+      "integrity": "sha512-U3K3FBMDNva4tasSy4YCL1ee8eAENTrsQ2dJStYLwqY9dpRXx8yumMUczJd77+n/ER+wZdQxyoFNg4iWPxoX5w==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.3.1"
@@ -4656,7 +4656,8 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4680,13 +4681,15 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4703,19 +4706,22 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4846,7 +4852,8 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4860,6 +4867,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4876,6 +4884,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4884,13 +4893,15 @@
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4911,6 +4922,7 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4999,7 +5011,8 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5013,6 +5026,7 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5108,7 +5122,8 @@
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5150,6 +5165,7 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5171,6 +5187,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5219,13 +5236,15 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "eslint-plugin-react": "^7.13.0",
     "eslint-plugin-react-hooks": "^1.6.0",
     "fast-deep-equal": "^2.0.1",
-    "final-form": "^4.15.0",
+    "final-form": "^4.16.0",
     "flow-bin": "^0.98.1",
     "glow": "^1.2.2",
     "husky": "^2.4.1",
@@ -89,7 +89,7 @@
     "typescript": "^3.5.2"
   },
   "peerDependencies": {
-    "final-form": "^4.15.0",
+    "final-form": "^4.16.0",
     "react": "^16.8.0"
   },
   "lint-staged": {

--- a/src/ReactFinalForm.js
+++ b/src/ReactFinalForm.js
@@ -56,7 +56,7 @@ function ReactFinalForm<FormValues: FormValuesShape>({
 }: Props<FormValues>) {
   const config: Config<FormValues> = {
     debug,
-    destroyOnUnregister,
+    destroyOnUnregister: false, // lie on first render because fields need to register twice
     initialValues,
     keepDirtyOnReinitialize,
     mutators,
@@ -89,6 +89,7 @@ function ReactFinalForm<FormValues: FormValuesShape>({
   React.useEffect(() => {
     // We have rendered, so all fields are no registered, so we can unpause validation
     form.isValidationPaused() && form.resumeValidation()
+    form.setConfig('destroyOnUnregister', destroyOnUnregister) // set the true value
     const unsubscriptions: Unsubscribe[] = [
       form.subscribe(s => {
         if (!shallowEqual(s, stateRef.current)) {

--- a/src/ReactFinalForm.js
+++ b/src/ReactFinalForm.js
@@ -56,7 +56,7 @@ function ReactFinalForm<FormValues: FormValuesShape>({
 }: Props<FormValues>) {
   const config: Config<FormValues> = {
     debug,
-    destroyOnUnregister: false, // lie on first render because fields need to register twice
+    destroyOnUnregister,
     initialValues,
     keepDirtyOnReinitialize,
     mutators,
@@ -89,7 +89,6 @@ function ReactFinalForm<FormValues: FormValuesShape>({
   React.useEffect(() => {
     // We have rendered, so all fields are no registered, so we can unpause validation
     form.isValidationPaused() && form.resumeValidation()
-    form.setConfig('destroyOnUnregister', destroyOnUnregister) // set the true value
     const unsubscriptions: Unsubscribe[] = [
       form.subscribe(s => {
         if (!shallowEqual(s, stateRef.current)) {
@@ -135,7 +134,7 @@ function ReactFinalForm<FormValues: FormValuesShape>({
     form.setConfig('debug', debug)
   })
   useWhenValueChanges(destroyOnUnregister, () => {
-    form.setConfig('destroyOnUnregister', destroyOnUnregister)
+    form.destroyOnUnregister = !!destroyOnUnregister
   })
   useWhenValueChanges(
     initialValues,

--- a/src/ReactFinalForm.test.js
+++ b/src/ReactFinalForm.test.js
@@ -962,4 +962,43 @@ describe('ReactFinalForm', () => {
     fireEvent.focus(getByTestId('name'))
     expect(getByTestId('name').value).toBe('erikras')
   })
+
+  it('should not destroy on unregister on initial register/unregister of new field', () => {
+    // https://github.com/final-form/react-final-form/issues/523
+    const { getByTestId, queryByTestId, getByText } = render(
+      <Form
+        onSubmit={onSubmitMock}
+        initialValues={{ name: 'erikras', password: 'f1nal-f0rm-RULEZ' }}
+        destroyOnUnregister
+      >
+        {({ handleSubmit }) => (
+          <form onSubmit={handleSubmit}>
+            <Field name="name" component="input" data-testid="name" />
+            <Toggle>
+              {showPassword =>
+                showPassword && (
+                  <Field
+                    name="password"
+                    component="input"
+                    type="password"
+                    data-testid="password"
+                  />
+                )
+              }
+            </Toggle>
+          </form>
+        )}
+      </Form>
+    )
+
+    expect(getByTestId('name')).toBeDefined()
+    expect(getByTestId('name').value).toBe('erikras')
+    fireEvent.focus(getByTestId('name'))
+    expect(getByTestId('name').value).toBe('erikras')
+    expect(queryByTestId('password')).toBe(null)
+    fireEvent.click(getByText('Toggle'))
+    expect(getByTestId('password').value).toBe('f1nal-f0rm-RULEZ')
+    fireEvent.focus(getByTestId('password'))
+    expect(getByTestId('password').value).toBe('f1nal-f0rm-RULEZ')
+  })
 })

--- a/src/ReactFinalForm.test.js
+++ b/src/ReactFinalForm.test.js
@@ -940,4 +940,26 @@ describe('ReactFinalForm', () => {
     expect(formMock.mock.calls[1][0]).toBe('name')
     expect(formMock.mock.calls[1][2].active).toBe(true) // default subscription
   })
+
+  it('should not destroy on unregister on initial unregister', () => {
+    // https://github.com/final-form/react-final-form/issues/523
+    const { getByTestId } = render(
+      <Form
+        onSubmit={onSubmitMock}
+        initialValues={{ name: 'erikras' }}
+        destroyOnUnregister
+      >
+        {({ handleSubmit }) => (
+          <form onSubmit={handleSubmit}>
+            <Field name="name" component="input" data-testid="name" />
+          </form>
+        )}
+      </Form>
+    )
+
+    expect(getByTestId('name')).toBeDefined()
+    expect(getByTestId('name').value).toBe('erikras')
+    fireEvent.focus(getByTestId('name'))
+    expect(getByTestId('name').value).toBe('erikras')
+  })
 })

--- a/src/useField.js
+++ b/src/useField.js
@@ -72,15 +72,13 @@ function useField<FormValues: FormValuesShape>(
   const firstRender = React.useRef(true)
 
   // synchronously register and unregister to query field state for our subscription on first render
-  const [state, setState] = React.useState<FieldState>(
-    (): FieldState => {
-      let initialState: FieldState = {}
-      register(state => {
-        initialState = state
-      })()
-      return initialState
-    }
-  )
+  const [state, setState] = React.useState<FieldState>((): FieldState => {
+    let initialState: FieldState = {}
+    register(state => {
+      initialState = state
+    })()
+    return initialState
+  })
 
   React.useEffect(
     () =>

--- a/src/useField.js
+++ b/src/useField.js
@@ -74,9 +74,18 @@ function useField<FormValues: FormValuesShape>(
   // synchronously register and unregister to query field state for our subscription on first render
   const [state, setState] = React.useState<FieldState>((): FieldState => {
     let initialState: FieldState = {}
+
+    // temporarily disable destroyOnUnregister
+    const destroyOnUnregister = form.destroyOnUnregister
+    form.destroyOnUnregister = false
+
     register(state => {
       initialState = state
     })()
+
+    // return destroyOnUnregister to its original value
+    form.destroyOnUnregister = destroyOnUnregister
+
     return initialState
   })
 


### PR DESCRIPTION
Fixes #523, ~~**_but only for initial fields_**~~.

~~Because our fields have to register twice on first render, the `destroyOnUnregister` will naturally destroy the value on first render. This PR fixes the bug for fields that are present on first form render, but will not fix it for new ones added.~~

**Update**: Works now for all fields, regardless of when they are added. 