### PR TITLE
Validating flag support

### DIFF
--- a/README.md
+++ b/README.md
@@ -705,6 +705,10 @@ The current value of the field.
 
 [See the 🏁 Final Form docs on `valid`](https://github.com/final-form/final-form#valid-boolean).
 
+#### `meta.validating?: boolean`
+
+[See the 🏁 Final Form docs on `validating`](https://github.com/final-form/final-form#validating-boolean).
+
 #### `meta.visited?: boolean`
 
 [See the 🏁 Final Form docs on `visited`](https://github.com/final-form/final-form#visited-boolean).

--- a/package-lock.json
+++ b/package-lock.json
@@ -4492,9 +4492,9 @@
       }
     },
     "final-form": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/final-form/-/final-form-4.16.0.tgz",
-      "integrity": "sha512-U3K3FBMDNva4tasSy4YCL1ee8eAENTrsQ2dJStYLwqY9dpRXx8yumMUczJd77+n/ER+wZdQxyoFNg4iWPxoX5w==",
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/final-form/-/final-form-4.16.1.tgz",
+      "integrity": "sha512-nUY6ZyFRvnOhSukqpmzm6pt38qYjCA6zSeW630CcfOvy0tBM+Wy0ZLIE36y/QiUfuAtMEJWp8k7GK5LqrqubEw==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.3.1"

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "eslint-plugin-react": "^7.13.0",
     "eslint-plugin-react-hooks": "^1.6.0",
     "fast-deep-equal": "^2.0.1",
-    "final-form": "^4.16.0",
+    "final-form": "^4.16.1",
     "flow-bin": "^0.98.1",
     "glow": "^1.2.2",
     "husky": "^2.4.1",
@@ -89,7 +89,7 @@
     "typescript": "^3.5.2"
   },
   "peerDependencies": {
-    "final-form": "^4.16.0",
+    "final-form": "^4.16.1",
     "react": "^16.8.0"
   },
   "lint-staged": {

--- a/src/Field.test.js
+++ b/src/Field.test.js
@@ -954,7 +954,7 @@ describe('Field', () => {
   })
 
   it('update validating flag on async field-level validation', async () => {
-    const { getByTestId, getByText } = render(
+    const { getByTestId } = render(
       <Form onSubmit={onSubmitMock}>
         {({ handleSubmit }) => (
           <form onSubmit={handleSubmit}>

--- a/src/useField.js
+++ b/src/useField.js
@@ -195,6 +195,7 @@ function useField<FormValues: FormValuesShape>(
     submitting: otherState.submitting,
     touched: otherState.touched,
     valid: otherState.valid,
+    validating: otherState.validating,
     visited: otherState.visited
   }
   if (formatOnBlur) {


### PR DESCRIPTION
Support for `final-form` [`v4.16.0`](https://github.com/final-form/final-form/releases/tag/v4.16.0)'s `validating` flag in the `meta` object.