### PR TITLE
Do not pass undefined type to input

### DIFF
--- a/src/Field.test.js
+++ b/src/Field.test.js
@@ -395,6 +395,23 @@ describe('Field', () => {
     expect(CustomSelect.mock.calls[0][0].input.multiple).toBe(true)
   })
 
+  it('should not pass an undefined type through to the input', () => {
+    const MyInput = jest.fn(({ input }) => <input {...input} />)
+    render(
+      <Form onSubmit={onSubmitMock} subscription={{ values: true }}>
+        {() => (
+          <form>
+            <Field name="name" component={MyInput} multiple />
+          </form>
+        )}
+      </Form>
+    )
+
+    expect(MyInput).toHaveBeenCalled()
+    expect(MyInput).toHaveBeenCalledTimes(1)
+    expect(MyInput.mock.calls[0][0].input).not.toHaveProperty('type')
+  })
+
   it('should optionally allow null values', () => {
     const spy = jest.fn()
     const { getByTestId } = render(

--- a/src/useField.js
+++ b/src/useField.js
@@ -208,7 +208,7 @@ function useField<FormValues: FormValuesShape>(
   if (value === null && !allowNull) {
     value = ''
   }
-  const input: FieldInputProps = { name, value, type, ...handlers }
+  const input: FieldInputProps = { name, value, ...handlers }
   if (type === 'checkbox') {
     if (_value === undefined) {
       input.checked = !!value
@@ -224,6 +224,9 @@ function useField<FormValues: FormValuesShape>(
   }
   if (multiple) {
     input.multiple = multiple
+  }
+  if (type !== undefined) {
+    input.type = type
   }
 
   const renderProps: FieldRenderProps = { input, meta } // assign to force Flow check


### PR DESCRIPTION
Some custom widgets (such as the SingleDatePicker in react-dates) have very strict prop types, that reject unknown props. So even `type={undefined}` will fail the prop type check.

With this PR `type` is only included in `input`, if it's not undefined.