### PR TITLE
Issue 175: pass any additional props to custom component

### DIFF
--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -31,6 +31,7 @@ interface FieldInputProps<FieldValue, T extends HTMLElement> {
   value: FieldValue;
   checked?: boolean;
   multiple?: boolean;
+  [key: string]: any;
 }
 
 interface AnyObject {


### PR DESCRIPTION
This PR for resolve [issue #175](https://github.com/final-form/react-final-form/issues/175)

Now u can add any additional props to your custom component. I use custom Select, so i need to pass label, options and anyAdditionalProp.

### How to use

**RenderForm.tsx**
```
<Field<string>
  name="stack"
  component={SelectAdapter}
  label="Tools"
  options={optionsArrayVariable}
  anyAdditionalProp={anyAdditionalProp}
/>
```

**FormAdapters.tsx (contain adapters for custom components)**
```
interface SelectAdapterProps extends HTMLElement {
  label?: string;
  options: Option[];
  anyAdditionalProp: any;
}

export const SelectAdapter = (props: FieldRenderProps<string, SelectAdapterProps>) => {
  const {
    input,
    meta,
    ...rest
  } = props;
  const {
    options,
    label,
    anyAdditionalProp,
  } = input;
  return (
    <Select
      options={options}
      label={label || ''}
      anyAdditionalProp={anyAdditionalProp}
      {...input}
      {...rest}
    />
  );
};
```