### PR TITLE
remove the use of Omit from the typescript definitions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11747,11 +11747,6 @@
       "integrity": "sha512-fwkLWH+DimvA4YCy+/nvJd61nWQQ2liO/nF/RjkTpiOGi+zxZzVkhb1mvbHIIW4b/8nDsYI8uTmAlc0nNkRMOw==",
       "dev": true
     },
-    "ts-essentials": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-2.0.8.tgz",
-      "integrity": "sha512-GCs7d/LHQvvgvWaHs2Wv/tDq4WwSZDlkYw9iE6orXaVFqL65P4oi5BE+7hYP0bByqoVwk8BJevmyzFwuGXAfKQ=="
-    },
     "tslib": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",

--- a/package.json
+++ b/package.json
@@ -123,7 +123,6 @@
     "url": "https://opencollective.com/final-form"
   },
   "dependencies": {
-    "@babel/runtime": "^7.4.5",
-    "ts-essentials": "^2.0.8"
+    "@babel/runtime": "^7.4.5"
   }
 }

--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -9,7 +9,6 @@ import {
   FieldSubscription,
   FieldValidator
 } from 'final-form';
-import { Omit } from 'ts-essentials';
 
 type SupportedInputs = 'input' | 'select' | 'textarea';
 
@@ -17,9 +16,12 @@ export interface ReactContext<FormValues> {
   reactFinalForm: FormApi<FormValues>;
 }
 
-export type FieldMetaState<FieldValue> = Omit<
+export type FieldMetaState<FieldValue> = Pick<
   FieldState<FieldValue>,
-  'blur' | 'change' | 'focus' | 'name' | 'value'
+  Exclude<
+    keyof FieldState<FieldValue>,
+    'blur' | 'change' | 'focus' | 'name' | 'value'
+  >
 >;
 
 interface FieldInputProps<FieldValue, T extends HTMLElement> {


### PR DESCRIPTION
The current typings depend upon `Omit<>` from `ts-essentials` but this is a common type that has been added by people (myself included) to their projects. The duplicate definition of `Omit<>` then causes the compiler to complain. `Omit<>` has since been added to [TS 3.5](https://devblogs.microsoft.com/typescript/announcing-typescript-3-5/#the-omit-helper-type) 

To work around this I have changed the use of the `Omit<>` type helper and replaced it with the more explicit use of `Pick<>` and `Exclude<>`.  This will prevent anyone that has their own `Omit<>` type or is targeting TS 3.5 from failing to build the project. The added bonus is that `ts-essentials` is no longer needed so there is one less dependency required :smiley_cat: 
