### PR TITLE
removes Omit from the typescript definitions

### DIFF
--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -9,7 +9,6 @@ import {
   FieldSubscription,
   FieldValidator
 } from 'final-form';
-import { Omit } from 'ts-essentials';
 
 type SupportedInputs = 'input' | 'select' | 'textarea';
 
@@ -17,9 +16,12 @@ export interface ReactContext<FormValues> {
   reactFinalForm: FormApi<FormValues>;
 }
 
-export type FieldMetaState<FieldValue> = Omit<
+export type FieldMetaState<FieldValue> = Pick<
   FieldState<FieldValue>,
-  'blur' | 'change' | 'focus' | 'name' | 'value'
+  Exclude<
+    keyof FieldState<FieldValue>,
+    'blur' | 'change' | 'focus' | 'name' | 'value'
+  >
 >;
 
 interface FieldInputProps<FieldValue, T extends HTMLElement> {


### PR DESCRIPTION
The current typings depend upon `Omit<>` from ts-essentials but this is a common type that has been added by people (myself included) to their projects. The duplicate definition of `Omit<>` causes the compiler to complain. `Omit<>` has also been [added to TS 3.5](https://devblogs.microsoft.com/typescript/announcing-typescript-3-5/#the-omit-helper-type) so this will cause a conflict for those people who are targeting 3.5

To work around this I have changed the use of the` Omit<>` type helper and replaced it with the more explicit use of `Pick<>` and `Exclude<>`. This will prevent anyone that has their own Omit<> type or is targeting TS 3.5 from failing to build the project. 

The added bonus is that ts-essentials is no longer needed so there is one less dependency required :smiley_cat:. However I decided not to remove this from the `package.json` as the reference to `final-form` is set as to use a `yalc` link. I do not have this setup so decided it is best left out of this PR.
