### PR TITLE
RFC: pausing validation before unmount

### DIFF
--- a/src/ReactFinalForm.js
+++ b/src/ReactFinalForm.js
@@ -106,7 +106,9 @@ function ReactFinalForm<FormValues: FormValuesShape>({
     ]
 
     return () => {
+      form.pauseValidation() // pause validation so we don't revalidate on every field deregistration
       unsubscriptions.forEach(unsubscribe => unsubscribe())
+      // don't need to resume validation here; either unmounting, or will re-run this hook with new deps
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [decorators])

--- a/src/ReactFinalForm.js
+++ b/src/ReactFinalForm.js
@@ -67,6 +67,7 @@ function ReactFinalForm<FormValues: FormValuesShape>({
 
   const form: FormApi<FormValues> = useConstant(() => {
     const f = alternateFormApi || createForm<FormValues>(config)
+    // pause validation until children register all fields on first render (unpaused in useEffect() below)
     f.pauseValidation()
     return f
   })
@@ -87,7 +88,7 @@ function ReactFinalForm<FormValues: FormValuesShape>({
   const stateRef = useLatest<FormState<FormValues>>(state)
 
   React.useEffect(() => {
-    // We have rendered, so all fields are no registered, so we can unpause validation
+    // We have rendered, so all fields are now registered, so we can unpause validation
     form.isValidationPaused() && form.resumeValidation()
     const unsubscriptions: Unsubscribe[] = [
       form.subscribe(s => {


### PR DESCRIPTION
I know that with classes this should go in `componentWillUnmount()`, but I'm not 100% clear on the semantics of `useEffect()`. Does it also run parent-first when a tree is being unmounted?

If this does what I expect it to, will fix #408. Will make a test case before removing the RFC tag.

<!--

👋 Hey, thanks for your interest in contributing to 🏁 React Final Form!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create an issue to first discuss any significant new
features.

Please try to keep your pull request focused in scope and avoid including
unrelated commits.

After you have submitted your pull request, we’ll try to get back to you as soon
as possible. We may suggest some changes or improvements.

Please format the code before submitting your pull request by running:

```
npm run precommit
```

https://github.com/final-form/react-final-form/blob/master/.github/CONTRIBUTING.md

-->
