### PR TITLE
Lazy evaluation of form and field state

### DIFF
--- a/src/Field.js
+++ b/src/Field.js
@@ -54,7 +54,8 @@ const Field = ({
     return React.createElement(component, { ...field.input, children, ...rest })
   }
   return renderComponent(
-    { ...field, children, component, ...rest },
+    { children, component, ...rest },
+    field,
     `Field(${name})`
   )
 }

--- a/src/FormSpy.js
+++ b/src/FormSpy.js
@@ -33,9 +33,9 @@ function FormSpy<FormValues: FormValuesShape>({
   return renderComponent(
     {
       ...rest,
-      ...state,
       ...renderProps
     },
+    state,
     'FormSpy'
   )
 }

--- a/src/ReactFinalForm.js
+++ b/src/ReactFinalForm.js
@@ -23,6 +23,7 @@ import type { FormRenderProps } from './types.js.flow'
 import ReactFinalFormContext from './context'
 import useLatest from './useLatest'
 import { version } from '../package.json'
+import { addLazyFormState } from './getters'
 
 export { version }
 
@@ -177,8 +178,6 @@ function ReactFinalForm<FormValues: FormValuesShape>({
   }
 
   const renderProps: FormRenderProps<FormValues> = {
-    // assign to force Flow check
-    ...state,
     form: {
       ...form,
       reset: eventOrValues => {
@@ -192,15 +191,16 @@ function ReactFinalForm<FormValues: FormValuesShape>({
     },
     handleSubmit
   }
+  addLazyFormState(renderProps, state)
   return React.createElement(
     ReactFinalFormContext.Provider,
     { value: form },
     renderComponent(
       {
         ...rest,
-        ...renderProps,
         __versions: versions
       },
+      renderProps,
       'ReactFinalForm'
     )
   )

--- a/src/getters.js
+++ b/src/getters.js
@@ -1,0 +1,57 @@
+import type { FormState, FieldState } from 'final-form'
+
+const addLazyState = (dest: Object, state: Object, keys: string[]): void => {
+  keys.forEach(key => {
+    Object.defineProperty(dest, key, {
+      get: () => state[key]
+    })
+  })
+}
+
+export const addLazyFormState = (dest: Object, state: FormState): void =>
+  addLazyState(dest, state, [
+    'active',
+    'dirty',
+    'dirtyFields',
+    'dirtySinceLastSubmit',
+    'error',
+    'errors',
+    'hasSubmitErrors',
+    'hasValidationErrors',
+    'initialValues',
+    'invalid',
+    'modified',
+    'pristine',
+    'submitError',
+    'submitErrors',
+    'submitFailed',
+    'submitSucceeded',
+    'submitting',
+    'touched',
+    'valid',
+    'validating',
+    'values',
+    'visited'
+  ])
+
+export const addLazyFieldMetaState = (dest: Object, state: FieldState): void =>
+  addLazyState(dest, state, [
+    'active',
+    'data',
+    'dirty',
+    'dirtySinceLastSubmit',
+    'error',
+    'initial',
+    'invalid',
+    'length',
+    'modified',
+    'pristine',
+    'submitError',
+    'submitFailed',
+    'submitSucceeded',
+    'submitting',
+    'touched',
+    'valid',
+    'validating',
+    'visited'
+  ])

--- a/src/renderComponent.js
+++ b/src/renderComponent.js
@@ -6,19 +6,30 @@ import type { RenderableProps } from './types'
 // children render function, or component prop
 export default function renderComponent<T>(
   props: RenderableProps<T> & T,
+  lazyProps: Object,
   name: string
 ): React.Node {
   const { render, children, component, ...rest } = props
   if (component) {
-    return React.createElement(component, { ...rest, children, render })
+    return React.createElement(component, {
+      ...rest,
+      ...lazyProps,
+      children,
+      render
+    })
   }
   if (render) {
-    return render(children === undefined ? rest : { ...rest, children }) // inject children back in
+    return render(
+      children === undefined
+        ? Object.assign(lazyProps, rest)
+        : // inject children back in
+          Object.assign(lazyProps, rest, { children })
+    )
   }
   if (typeof children !== 'function') {
     throw new Error(
       `Must specify either a render prop, a render function as children, or a component prop to ${name}`
     )
   }
-  return children(rest)
+  return children(Object.assign(lazyProps, rest))
 }

--- a/src/renderComponent.test.js
+++ b/src/renderComponent.test.js
@@ -10,7 +10,7 @@ describe('renderComponent', () => {
       render
     }
     const name = 'TestComponent'
-    const result = renderComponent(props, name)
+    const result = renderComponent(props, {}, name)
     expect(result.props).toEqual({ children, render })
   })
 
@@ -22,7 +22,7 @@ describe('renderComponent', () => {
       render
     }
     const name = 'TestComponent'
-    renderComponent(props, name)
+    renderComponent(props, {}, name)
     expect(render).toHaveBeenCalled()
     expect(render).toHaveBeenCalledTimes(1)
     expect(render.mock.calls[0][0].children).toBe(children)
@@ -34,8 +34,39 @@ describe('renderComponent', () => {
       children
     }
     const name = 'TestComponent'
-    expect(() => renderComponent(props, name)).toThrow(
+    expect(() => renderComponent(props, {}, name)).toThrow(
       `Must specify either a render prop, a render function as children, or a component prop to ${name}`
     )
+  })
+
+  it('should not evaluate any of the keys given in the second argument', () => {
+    const children = 'some children'
+    const render = jest.fn()
+    const props = {
+      children,
+      render
+    }
+    const getA = jest.fn()
+    const getB = jest.fn()
+    const name = 'TestComponent'
+    renderComponent(
+      props,
+      {
+        get a() {
+          getA()
+          return 1
+        },
+        get b() {
+          getB()
+          return 2
+        }
+      },
+      name
+    )
+    expect(render).toHaveBeenCalled()
+    expect(render).toHaveBeenCalledTimes(1)
+    expect(render.mock.calls[0][0].children).toBe(children)
+    expect(getA).not.toHaveBeenCalled()
+    expect(getB).not.toHaveBeenCalled()
   })
 })

--- a/src/types.js.flow
+++ b/src/types.js.flow
@@ -46,6 +46,7 @@ export type FieldRenderProps = {
     submitting?: boolean,
     touched?: boolean,
     valid?: boolean,
+    validating?: boolean,
     visited?: boolean
   }
 }
@@ -73,7 +74,7 @@ export type FormProps<FormValues: FormValuesShape> = {
 } & Config<FormValues> &
   RenderableProps<FormRenderProps<FormValues>>
 
-export type UseFieldConfig = {
+export type UseFieldAutoConfig = {
   afterSubmit?: () => void,
   allowNull?: boolean,
   beforeSubmit?: () => void | false,
@@ -86,12 +87,15 @@ export type UseFieldConfig = {
   isEqual?: (a: any, b: any) => boolean,
   multiple?: boolean,
   parse?: (value: any, name: string) => any,
-  subscription?: FieldSubscription,
   type?: string,
   validate?: FieldValidator,
   validateFields?: string[],
   value?: any
 }
+
+export type UseFieldConfig = {
+  subscription?: FieldSubscription
+} & UseFieldAutoConfig
 
 export type FieldProps = UseFieldConfig & {
   name: string

--- a/src/useField.test.js
+++ b/src/useField.test.js
@@ -34,6 +34,42 @@ describe('useField', () => {
     console.error.mockRestore()
   })
 
+  it('should subscribe to all by default', () => {
+    const MyFieldListener = () => {
+      const { input, meta } = useField('name')
+      expect(meta.active).toBe(false)
+      expect(meta.data).toEqual({})
+      expect(meta.dirty).toBe(false)
+      expect(meta.dirtySinceLastSubmit).toBe(false)
+      expect(meta.error).toBeUndefined()
+      expect(meta.initial).toBeUndefined()
+      expect(meta.invalid).toBe(false)
+      expect(meta.length).toBeUndefined()
+      expect(meta.modified).toBe(false)
+      expect(meta.pristine).toBe(true)
+      expect(meta.submitError).toBeUndefined()
+      expect(meta.submitFailed).toBe(false)
+      expect(meta.submitSucceeded).toBe(false)
+      expect(meta.submitting).toBe(false)
+      expect(meta.touched).toBe(false)
+      expect(meta.valid).toBe(true)
+      expect(meta.validating).toBe(false)
+      expect(meta.visited).toBe(false)
+      expect(input.value).toBe('')
+      return null
+    }
+    render(
+      <Form onSubmit={onSubmitMock}>
+        {() => (
+          <form>
+            <Field name="name" component="input" data-testid="name" />
+            <MyFieldListener />
+          </form>
+        )}
+      </Form>
+    )
+  })
+
   it('should track field state', () => {
     const spy = jest.fn()
     const MyFieldListener = () => {

--- a/src/useFormState.js
+++ b/src/useFormState.js
@@ -4,6 +4,7 @@ import type { UseFormStateParams } from './types'
 import type { FormState, FormApi, FormValuesShape } from 'final-form'
 import { all } from './ReactFinalForm'
 import useForm from './useForm'
+import { addLazyFormState } from './getters'
 
 function useFormState<FormValues: FormValuesShape>({
   onChange,
@@ -43,7 +44,9 @@ function useFormState<FormValues: FormValuesShape>({
     // eslint-disable-next-line react-hooks/exhaustive-deps
     []
   )
-  return state
+  const lazyState = {}
+  addLazyFormState(lazyState, state)
+  return lazyState
 }
 
 export default useFormState


### PR DESCRIPTION
Has the added benefit of making all the state values readonly.

That should only be a breaking change for the naughtiest of users.