### PR TITLE
Fix typescript typings in FieldProps

### DIFF
--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -77,12 +77,12 @@ export interface UseFieldConfig<FieldValue> {
   allowNull?: boolean;
   beforeSubmit?: () => void | boolean;
   defaultValue?: FieldValue;
-  format?: (value: FieldValue, name: string) => any;
+  format?: (value: any, name: string) => any;
   formatOnBlur?: boolean;
   initialValue?: FieldValue;
   isEqual?: (a: any, b: any) => boolean;
   multiple?: boolean;
-  parse?: (value: any, name: string) => FieldValue;
+  parse?: (value: FieldValue, name: string) => FieldValue;
   subscription?: FieldSubscription;
   type?: string;
   validate?: FieldValidator<FieldValue>;


### PR DESCRIPTION
According to [the doc](https://final-form.org/docs/react-final-form/types/FieldProps#parse) the parse prop takes the value from the input (which is typed with `FieldValue`)

<!--

👋 Hey, thanks for your interest in contributing to 🏁 React Final Form!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create an issue to first discuss any significant new
features.

Please try to keep your pull request focused in scope and avoid including
unrelated commits.

After you have submitted your pull request, we’ll try to get back to you as soon
as possible. We may suggest some changes or improvements.

Please format the code before submitting your pull request by running:

```
npm run precommit
```

https://github.com/final-form/react-final-form/blob/master/.github/CONTRIBUTING.md

-->
