### PR TITLE
useField: Pass in falsy getValidator where possible

### DIFF
--- a/src/useField.js
+++ b/src/useField.js
@@ -64,7 +64,7 @@ function useField<FormValues: FormValuesShape>(
       afterSubmit,
       beforeSubmit: () => beforeSubmitRef.current(),
       defaultValue,
-      getValidator: () => validateRef.current,
+      getValidator: validateRef.current && (() => validateRef.current),
       initialValue,
       isEqual,
       validateFields


### PR DESCRIPTION
final-form skips a bunch of moderately expensive work when
getValidator() for a field is null. When the user has passed in a falsy
"validate" prop, we should take advantage of this by not passing in a
no-op getValidator() function.

<!--

👋 Hey, thanks for your interest in contributing to 🏁 React Final Form!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create an issue to first discuss any significant new
features.

Please try to keep your pull request focused in scope and avoid including
unrelated commits.

After you have submitted your pull request, we’ll try to get back to you as soon
as possible. We may suggest some changes or improvements.

Please format the code before submitting your pull request by running:

```
npm run precommit
```

https://github.com/final-form/react-final-form/blob/master/.github/CONTRIBUTING.md

-->
