### PR TITLE
[ts] fix FormProps['decorators']

### DIFF
--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -67,7 +67,7 @@ export interface FormProps<FormValues = AnyObject>
   extends Config<FormValues>,
     RenderableProps<FormRenderProps<FormValues>> {
   subscription?: FormSubscription;
-  decorators?: Decorator[];
+  decorators?: Array<Decorator<FormValues>>;
   form?: FormApi<FormValues>;
   initialValuesEqual?: (a?: AnyObject, b?: AnyObject) => boolean;
 }


### PR DESCRIPTION
This PR fixes `Type 'Decorator<IValues>[]' is not assignable to type 'Decorator<object>[]'.` error when decorator is typed with signature `Decorator<IValues>`
  