### PR TITLE
Fix initialValue overrides value if a field is re-mounted

### DIFF
--- a/src/useField.js
+++ b/src/useField.js
@@ -59,13 +59,13 @@ function useField<FormValues: FormValuesShape>(
     return beforeSubmit && beforeSubmit()
   })
 
-  const register = (callback: FieldState => void) =>
+  const register = (callback: FieldState => void, omitInitialValue: ?boolean) =>
     form.registerField(name, callback, subscription, {
       afterSubmit,
       beforeSubmit: () => beforeSubmitRef.current(),
       defaultValue,
       getValidator: () => validateRef.current,
-      initialValue,
+      initialValue: omitInitialValue ? undefined : initialValue,
       isEqual,
       validateFields
     })
@@ -80,9 +80,16 @@ function useField<FormValues: FormValuesShape>(
     const destroyOnUnregister = form.destroyOnUnregister
     form.destroyOnUnregister = false
 
+    // Avoid passing initialValue if the field value is present in form already
+    // as initialValue will overwrite value if a field is re-mounted
+    let formState = form.getState()
+    const _initialValue =
+      formState && formState.values && formState.values[name]
+    const omitInitialValue = _initialValue !== undefined
+
     register(state => {
       initialState = state
-    })()
+    }, omitInitialValue)()
 
     // return destroyOnUnregister to its original value
     form.destroyOnUnregister = destroyOnUnregister


### PR DESCRIPTION
This fixes issues #533 and #536.

This PR makes RFF not pass `initialValue` to `registerField` if there is a `value` for the provided key in the form already present.

My use case for this is that my form is rather huge, it's a settings dialog with several tabs, each containing a dozen of fields. Most fields are in separate components and manage their own initial state and onSubmit logic so using initial state on form level and all other logic in the fields is not an option. So when tabs are switched the fields get unmounted and values get reset if user switches back to a tab.
