### PR TITLE
Make HTMLElement generic default and optional

### DIFF
--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -24,7 +24,7 @@ export type FieldMetaState<FieldValue> = Pick<
   >
 >;
 
-interface FieldInputProps<FieldValue, T extends HTMLElement> extends AnyObject {
+interface FieldInputProps<FieldValue, T extends HTMLElement = HTMLElement> extends AnyObject {
   name: string;
   onBlur: (event?: React.FocusEvent<T>) => void;
   onChange: (event: React.ChangeEvent<T> | any) => void;
@@ -39,7 +39,7 @@ interface AnyObject {
   [key: string]: any;
 }
 
-export interface FieldRenderProps<FieldValue, T extends HTMLElement> {
+export interface FieldRenderProps<FieldValue, T extends HTMLElement = HTMLElement> {
   input: FieldInputProps<FieldValue, T>;
   meta: FieldMetaState<FieldValue>;
 }
@@ -93,7 +93,7 @@ export interface UseFieldConfig<FieldValue> {
 export interface FieldProps<
   FieldValue,
   RP extends FieldRenderProps<FieldValue, T>,
-  T extends HTMLElement
+  T extends HTMLElement = HTMLElement
 > extends UseFieldConfig<FieldValue>, RenderableProps<RP> {
   name: string;
   [otherProp: string]: any;


### PR DESCRIPTION
Similar to other occurences of default type `T extends HTMLElement = HTMLElement` in the typings file.
It is very handy to not be required to add specific HTMLElement generic if, for example, I am using custom "inputs" or if I only need to use parts of the interface that don't use the second generic.

It is actually more often that I don't need the second generic.

<!--

👋 Hey, thanks for your interest in contributing to 🏁 React Final Form!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create an issue to first discuss any significant new
features.

Please try to keep your pull request focused in scope and avoid including
unrelated commits.

After you have submitted your pull request, we’ll try to get back to you as soon
as possible. We may suggest some changes or improvements.

Please format the code before submitting your pull request by running:

```
npm run precommit
```

https://github.com/final-form/react-final-form/blob/master/.github/CONTRIBUTING.md

-->
