### PR TITLE
Pass FormValues type to Decorator

### DIFF
--- a/typescript/ReactFinalForm.test.tsx
+++ b/typescript/ReactFinalForm.test.tsx
@@ -1,5 +1,5 @@
 /* tslint:disable: no-shadowed-variable */
-import { Mutator } from 'final-form';
+import { Mutator, Decorator } from 'final-form';
 import * as React from 'react';
 import { Field, Form } from 'react-final-form';
 
@@ -131,7 +131,9 @@ function mutated() {
   );
 }
 
-const typedOnSubmit = (values: { firstName: string }) => {
+type UserForm = { firstName: string; lastName: string };
+
+const typedOnSubmit = (values: UserForm) => {
   // tslint:disable-next-line no-console
   console.log(values);
 };
@@ -139,7 +141,7 @@ const typedOnSubmit = (values: { firstName: string }) => {
 // with typed form data and field
 function withTypedFormData() {
   return (
-    <Form<{ firstName: string }> onSubmit={typedOnSubmit}>
+    <Form<UserForm> onSubmit={typedOnSubmit}>
       {({ handleSubmit }) => (
         <form onSubmit={handleSubmit}>
           <div>
@@ -155,5 +157,27 @@ function withTypedFormData() {
         </form>
       )}
     </Form>
+  );
+}
+
+const decorator: Decorator<UserForm> = form => {
+  return form.subscribe(({ values: { firstName } }) => console.log(firstName), {
+    values: true
+  });
+};
+
+// with typed decorator
+function withTypedDecorator() {
+  return <Form<UserForm> decorators={[decorator]} onSubmit={typedOnSubmit} />;
+}
+
+// with wrong typed decorator
+function withWrongTypedDecorator() {
+  return (
+    <Form<Omit<UserForm, 'firstName'>>
+      // $ExpectError
+      decorators={[decorator]}
+      onSubmit={console.log}
+    />
   );
 }

--- a/typescript/ReactFinalForm.test.tsx
+++ b/typescript/ReactFinalForm.test.tsx
@@ -1,5 +1,7 @@
 /* tslint:disable: no-shadowed-variable */
-import { Mutator, Decorator } from 'final-form';
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+import { Decorator, Mutator } from 'final-form';
 import * as React from 'react';
 import { Field, Form } from 'react-final-form';
 
@@ -131,7 +133,10 @@ function mutated() {
   );
 }
 
-type UserForm = { firstName: string; lastName: string };
+interface UserForm {
+  firstName: string;
+  lastName: string;
+}
 
 const typedOnSubmit = (values: UserForm) => {
   // tslint:disable-next-line no-console
@@ -161,7 +166,7 @@ function withTypedFormData() {
 }
 
 const decorator: Decorator<UserForm> = form => {
-  return form.subscribe(({ values: { firstName } }) => console.log(firstName), {
+  return form.subscribe(({ values: { firstName } }) => firstName, {
     values: true
   });
 };
@@ -177,7 +182,7 @@ function withWrongTypedDecorator() {
     <Form<Omit<UserForm, 'firstName'>>
       // $ExpectError
       decorators={[decorator]}
-      onSubmit={console.log}
+      onSubmit={noop}
     />
   );
 }

--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -67,7 +67,7 @@ export interface FormProps<FormValues = AnyObject>
   extends Config<FormValues>,
     RenderableProps<FormRenderProps<FormValues>> {
   subscription?: FormSubscription;
-  decorators?: Decorator[];
+  decorators?: Decorator<FormValues>[];
   form?: FormApi<FormValues>;
   initialValuesEqual?: (a?: AnyObject, b?: AnyObject) => boolean;
 }

--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -67,7 +67,7 @@ export interface FormProps<FormValues = AnyObject>
   extends Config<FormValues>,
     RenderableProps<FormRenderProps<FormValues>> {
   subscription?: FormSubscription;
-  decorators?: Decorator<FormValues>[];
+  decorators?: Array<Decorator<FormValues>>;
   form?: FormApi<FormValues>;
   initialValuesEqual?: (a?: AnyObject, b?: AnyObject) => boolean;
 }


### PR DESCRIPTION
When from values are typed (suppose `T`) and we pass some decorators, instead `Decorator<T>[]`  decorator prop's type resolves to `Decorator<object>[]`.

So correctly typed decorators with correctly typed form process type error.