### PR TITLE
Update codesandbox field-warnings example

### DIFF
--- a/examples/field-warnings/index.js
+++ b/examples/field-warnings/index.js
@@ -14,7 +14,10 @@ const onSubmit = async values => {
 
 const App = () => (
   <Styles>
-    <h1>🏁 React Final Form Example</h1>
+    <h1><span role="img" aria-label="final form flag">
+        🏁
+      </span>{' '}React Final Form Example
+    </h1>
     <h2>⚠️ Warnings ⚠️</h2>
     <a href="https://github.com/erikras/react-final-form#-react-final-form">
       Read Docs

--- a/examples/field-warnings/index.js
+++ b/examples/field-warnings/index.js
@@ -1,53 +1,27 @@
-import React from 'react'
-import { render } from 'react-dom'
-import Styles from './Styles'
-import { Form, FormSpy, Field } from 'react-final-form'
-import setFieldData from 'final-form-set-field-data'
+import React from "react";
+import { render } from "react-dom";
+import Styles from "./Styles";
+import { WarningEngine } from "./warning-engine";
+import { Form, Field } from "react-final-form";
+import setFieldData from "final-form-set-field-data";
 
-const sleep = ms => new Promise(resolve => setTimeout(resolve, ms))
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 
 const onSubmit = async values => {
-  await sleep(300)
-  window.alert(JSON.stringify(values, 0, 2))
-}
-
-const WarningEngine = ({ mutators: { setFieldData } }) => (
-  <FormSpy
-    subscription={{ values: true }}
-    onChange={({ values }) => {
-      setFieldData('firstName', {
-        warning: values.firstName ? undefined : 'Recommended'
-      })
-      setFieldData('lastName', {
-        warning: values.lastName ? undefined : 'Recommended'
-      })
-    }}
-  />
-)
+  await sleep(300);
+  window.alert(JSON.stringify(values, 0, 2));
+};
 
 const App = () => (
   <Styles>
-    <h1>
-      <span role="img" aria-label="final form flag">
-        🏁
-      </span>{' '}
-      React Final Form Example
-    </h1>
-    <h2>
-      <span role="img" aria-label="warning icon">
-        ⚠️
-      </span>{' '}
-      Warnings{' '}
-      <span role="img" aria-label="warning icon">
-        ⚠️
-      </span>
-    </h2>
+    <h1>🏁 React Final Form Example</h1>
+    <h2>⚠️ Warnings ⚠️</h2>
     <a href="https://github.com/erikras/react-final-form#-react-final-form">
       Read Docs
     </a>
     <p>
       Warnings, in this example, are defined as: suggestions to the user, like
-      validation errors, but that do not prevent submission. Note that the{' '}
+      validation errors, but that do not prevent submission. Note that the{" "}
       <code>&lt;WarningEngine/&gt;</code> component must be at the bottom of the
       form to guarantee that all the fields have registered.
     </p>
@@ -57,52 +31,54 @@ const App = () => (
       render={({
         handleSubmit,
         reset,
-        mutators,
+        form: { mutators },
         submitting,
         pristine,
         values
-      }) => (
-        <form onSubmit={handleSubmit}>
-          <Field name="firstName">
-            {({ input, meta }) => (
-              <div>
-                <label>First Name</label>
-                <input {...input} placeholder="First Name" />
-                {meta.touched && meta.data.warning && (
-                  <span>{meta.data.warning}</span>
-                )}
-              </div>
-            )}
-          </Field>
-          <Field name="lastName">
-            {({ input, meta }) => (
-              <div>
-                <label>Last Name</label>
-                <input {...input} placeholder="Last Name" />
-                {meta.touched && meta.data.warning && (
-                  <span>{meta.data.warning}</span>
-                )}
-              </div>
-            )}
-          </Field>
-          <div className="buttons">
-            <button type="submit" disabled={submitting}>
-              Submit
-            </button>
-            <button
-              type="button"
-              onClick={reset}
-              disabled={submitting || pristine}
-            >
-              Reset
-            </button>
-          </div>
-          <pre>{JSON.stringify(values, 0, 2)}</pre>
-          <WarningEngine mutators={mutators} />
-        </form>
-      )}
+      }) => {
+        return (
+          <form onSubmit={handleSubmit}>
+            <Field name="firstName">
+              {({ input, meta }) => (
+                <div>
+                  <label>First Name</label>
+                  <input {...input} placeholder="First Name" />
+                  {meta.touched && meta.data.warning && (
+                    <span>{meta.data.warning}</span>
+                  )}
+                </div>
+              )}
+            </Field>
+            <Field name="lastName">
+              {({ input, meta }) => (
+                <div>
+                  <label>Last Name</label>
+                  <input {...input} placeholder="Last Name" />
+                  {meta.touched && meta.data.warning && (
+                    <span>{meta.data.warning}</span>
+                  )}
+                </div>
+              )}
+            </Field>
+            <div className="buttons">
+              <button type="submit" disabled={submitting}>
+                Submit
+              </button>
+              <button
+                type="button"
+                onClick={reset}
+                disabled={submitting || pristine}
+              >
+                Reset
+              </button>
+            </div>
+            <pre>{JSON.stringify(values, 0, 2)}</pre>
+            <WarningEngine mutators={mutators} />
+          </form>
+        );
+      }}
     />
   </Styles>
-)
+);
 
-render(<App />, document.getElementById('root'))
+render(<App />, document.getElementById("root"));

--- a/examples/field-warnings/index.js
+++ b/examples/field-warnings/index.js
@@ -18,7 +18,11 @@ const App = () => (
         🏁
       </span>{' '}React Final Form Example
     </h1>
-    <h2>⚠️ Warnings ⚠️</h2>
+    <h2>
+      <span role="img" aria-label="final form flag">⚠️</span>
+        {' '}Warnings{' '}
+      <span role="img" aria-label="final form flag">⚠️</span>
+    </h2>
     <a href="https://github.com/erikras/react-final-form#-react-final-form">
       Read Docs
     </a>

--- a/examples/field-warnings/readme.md
+++ b/examples/field-warnings/readme.md
@@ -1,3 +1,3 @@
 # Field Warnings
 
-[![Edit react-final-form-field-warnings-example](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/m5qwxpr6o8)
+[![Edit react-final-form-field-warnings-example](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/react-final-form-warnings-0nimt)

--- a/examples/field-warnings/warning-engine.js
+++ b/examples/field-warnings/warning-engine.js
@@ -1,0 +1,16 @@
+import React from "react";
+import { FormSpy } from "react-final-form";
+
+export const WarningEngine = ({ mutators: { setFieldData } }) => (
+  <FormSpy
+    subscription={{ values: true }}
+    onChange={({ values }) => {
+      setFieldData("firstName", {
+        warning: values.firstName ? undefined : "Recommended"
+      });
+      setFieldData("lastName", {
+        warning: values.lastName ? undefined : "Recommended"
+      });
+    }}
+  />
+);


### PR DESCRIPTION
see #576  and #680 

The current example does not reflect the new location of `mutators` on the `form` prop. This PR updates the code and codesandbox link.

This PR uses the updates provided by @abrad45 in #680 but src could also be copied from #576 if desired.