### PR TITLE
Fix doc links to FieldRenderProps

### DIFF
--- a/docs/types/FieldProps.md
+++ b/docs/types/FieldProps.md
@@ -188,7 +188,7 @@ A function that takes the value from the input and name of the field and convert
 
 Optional. (if you specify [`component`](#component) or [`children`](#children))
 
-A render function that is given [`FieldRenderProps`](types/FieldRenderProps), as well as any non-API props passed into the `<Field/>` component. For example, if you did...
+A render function that is given [`FieldRenderProps`](FieldRenderProps), as well as any non-API props passed into the `<Field/>` component. For example, if you did...
 
 ```tsx
 <Field
@@ -205,7 +205,7 @@ Note that if you specify `render` _and_ [`children`](#children), `render` will b
 
 Related:
 
-- [`FieldRenderProps`](types/FormRenderProps)
+- [`FieldRenderProps`](FormRenderProps)
 
 ## `subscription`
 


### PR DESCRIPTION
👋These two links are broken in https://final-form.org/docs/react-final-form/types/FieldProps