### PR TITLE
Fix handleSubmit typings

### DIFF
--- a/src/ReactFinalForm.js
+++ b/src/ReactFinalForm.js
@@ -13,7 +13,7 @@ import type {
   FormValuesShape,
   Unsubscribe
 } from 'final-form'
-import type { FormProps as Props } from './types'
+import type { FormProps as Props, SubmitEvent } from './types'
 import renderComponent from './renderComponent'
 import useWhenValueChanges from './useWhenValueChanges'
 import useConstant from './useConstant'
@@ -163,7 +163,7 @@ function ReactFinalForm<FormValues: FormValuesShape>({
     form.setConfig('validateOnBlur', validateOnBlur)
   })
 
-  const handleSubmit = (event: ?SyntheticEvent<HTMLFormElement>) => {
+  const handleSubmit = (event: ?SubmitEvent) => {
     if (event) {
       // sometimes not true, e.g. React Native
       if (typeof event.preventDefault === 'function') {

--- a/src/types.js.flow
+++ b/src/types.js.flow
@@ -51,8 +51,16 @@ export type FieldRenderProps = {
   }
 }
 
+export type SubmitEvent = {
+  preventDefault?: $PropertyType<SyntheticEvent<EventTarget>, 'preventDefault'>,
+  stopPropagation?: $PropertyType<
+    SyntheticEvent<EventTarget>,
+    'stopPropagation'
+  >
+}
+
 export type FormRenderProps<FormValues: FormValuesShape> = {
-  handleSubmit: (?SyntheticEvent<HTMLFormElement>) => ?Promise<?Object>,
+  handleSubmit: (?SubmitEvent) => ?Promise<?Object>,
   form: FormApi<FormValues>
 } & FormState<FormValues>
 

--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -24,7 +24,8 @@ export type FieldMetaState<FieldValue> = Pick<
   >
 >;
 
-interface FieldInputProps<FieldValue, T extends HTMLElement = HTMLElement> extends AnyObject {
+interface FieldInputProps<FieldValue, T extends HTMLElement = HTMLElement>
+  extends AnyObject {
   name: string;
   onBlur: (event?: React.FocusEvent<T>) => void;
   onChange: (event: React.ChangeEvent<T> | any) => void;
@@ -39,16 +40,22 @@ interface AnyObject {
   [key: string]: any;
 }
 
-export interface FieldRenderProps<FieldValue, T extends HTMLElement = HTMLElement> {
+export interface FieldRenderProps<
+  FieldValue,
+  T extends HTMLElement = HTMLElement
+> {
   input: FieldInputProps<FieldValue, T>;
   meta: FieldMetaState<FieldValue>;
 }
 
 export interface FormRenderProps<FormValues = AnyObject>
-  extends FormState<FormValues>, RenderableProps<FormRenderProps<FormValues>> {
+  extends FormState<FormValues>,
+    RenderableProps<FormRenderProps<FormValues>> {
   form: FormApi<FormValues>;
   handleSubmit: (
-    event?: React.SyntheticEvent<HTMLFormElement>
+    event?: Partial<
+      Pick<React.SyntheticEvent, 'preventDefault' | 'stopPropagation'>
+    >
   ) => Promise<AnyObject | undefined> | undefined;
 }
 


### PR DESCRIPTION
Fixes #86 

The typescript typings work in my local code - in this case, with a button handler, but it should work in React Native typescript typings as well.

Let me know if the flow typings changes are fine - i did my best 😄 .

<!--

👋 Hey, thanks for your interest in contributing to 🏁 React Final Form!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create an issue to first discuss any significant new
features.

Please try to keep your pull request focused in scope and avoid including
unrelated commits.

After you have submitted your pull request, we’ll try to get back to you as soon
as possible. We may suggest some changes or improvements.

Please format the code before submitting your pull request by running:

```
npm run precommit
```

https://github.com/final-form/react-final-form/blob/master/.github/CONTRIBUTING.md

-->
