### PR TITLE
Add otherProp to FieldRenderProps interface

### DIFF
--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -42,6 +42,7 @@ interface AnyObject {
 export interface FieldRenderProps<FieldValue, T extends HTMLElement = HTMLElement> {
   input: FieldInputProps<FieldValue, T>;
   meta: FieldMetaState<FieldValue>;
+  [otherProp: string]: any;
 }
 
 export interface FormRenderProps<FormValues = AnyObject>


### PR DESCRIPTION
I believe that the FieldRenderProps interface is typed incorrectly, it should actually allow `[otherProp: string]: any;`. Trying to access props other than `input` or `meta` will currently result in a Typescript error.

As shown in the docs [here](https://final-form.org/docs/react-final-form/types/FieldProps#children) arbitrary props assigned to the `Field` component are passed through to the renderProp.

```js
<Field name="myField" someArbitraryOtherProp={42}>
  {props => {
    console.log(props.someArbitraryOtherProp) // would print 42
    return <input {...props.input}/>
  }}
</Form>
```

We can see the passing of props in the `renderComponent` module here: https://github.com/final-form/react-final-form/blob/master/src/renderComponent.js#L25

# Related issue

Seems an issue is already raised regarding this:

https://github.com/final-form/react-final-form/issues/398

<!--

👋 Hey, thanks for your interest in contributing to 🏁 React Final Form!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create an issue to first discuss any significant new
features.

Please try to keep your pull request focused in scope and avoid including
unrelated commits.

After you have submitted your pull request, we’ll try to get back to you as soon
as possible. We may suggest some changes or improvements.

Please format the code before submitting your pull request by running:

```
npm run precommit
```

https://github.com/final-form/react-final-form/blob/master/.github/CONTRIBUTING.md

-->
