### PR TITLE
Switch to standard funding notice

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
     "start": "nps",
     "test": "nps test",
     "precommit": "lint-staged && npm start validate",
-    "prepublish": "npm start validate",
-    "postinstall": "node -e \"console.log('\\u001b[35m\\u001b[1mUsing react-final-form at work? You can now donate to our open collective:\\u001b[22m\\u001b[39m\\n > \\u001b[34mhttps://opencollective.com/final-form/donate\\u001b[0m')\""
+    "prepublish": "npm start validate"
   },
   "author": "Erik Rasmussen <rasmussenerik@gmail.com> (http://github.com/erikras)",
   "license": "MIT",
@@ -120,6 +119,10 @@
     }
   ],
   "collective": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/final-form"
+  },
+  "funding": {
     "type": "opencollective",
     "url": "https://opencollective.com/final-form"
   },


### PR DESCRIPTION
Now that there's a standard way for npm to display requests for funding, that most other packages have adopted, I figured it would be a reasonable change for react-final-form as well.