### PR TITLE
Fix doc link to FAQ section about "external submit"

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -115,7 +115,7 @@ use case, if migrating from `FormSection` should be handled.
 
 Demonstrates how you can use `document.getElementById()` or a closure to trigger
 a submit from outside of the form. For more information, see
-[How can I trigger a submit from outside the form?](docs/faq.md#how-can-i-trigger-a-submit-from-outside-my-form)
+[How can I trigger a submit from outside the form?](https://final-form.org/docs/react-final-form/faq#how-can-i-trigger-a-submit-from-outside-my-form)
 
 ### [Wizard Form](examples/wizard)
 


### PR DESCRIPTION
The link to the "external submit" FAQ section was not working on the docs site (https://final-form.org/docs/react-final-form/examples#external-submit). This PR fixes this by adding the link explicitly.