### PR TITLE
re-initialize onFocus/onBlur handlers if the subscribed field changes

### DIFF
--- a/src/useField.js
+++ b/src/useField.js
@@ -147,7 +147,7 @@ function useField<FormValues: FormValuesShape>(
         }
       },
       // eslint-disable-next-line react-hooks/exhaustive-deps
-      [state.name, format, formatOnBlur]
+      [state.blur, state.name, format, formatOnBlur]
     ),
     onChange: React.useCallback(
       (event: SyntheticInputEvent<*> | any) => {
@@ -183,10 +183,13 @@ function useField<FormValues: FormValuesShape>(
       // eslint-disable-next-line react-hooks/exhaustive-deps
       [_value, name, parse, state.change, state.value, type]
     ),
-    onFocus: React.useCallback((event: ?SyntheticFocusEvent<*>) => {
-      state.focus()
+    onFocus: React.useCallback(
+      (event: ?SyntheticFocusEvent<*>) => {
+        state.focus()
+      },
       // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [])
+      [state.focus]
+    )
   }
 
   const meta = {}


### PR DESCRIPTION
If you use `useField` (or `<Field>`) and the name of the field that you subscribe to changes during the lifetime of the component, the `onFocus` handler will continue calling the `state.focus()`  function of the previous field.

The reason is that `useField` doesn't specify the `state.focus` as a dependency for `React.useCallback`.

It is a common use-case with forms that you, for example, have a list of items, and you want to be able to toggle between the active item that you are editing, but not render all the items in DOM, rather just the one you're editing. At the moment in these use-cases when switching between the active item, the `Field` does not re-mount and the handlers will not work properly.