### PR TITLE
Deduce select type from component prop for select-multiple

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ cache:
 notifications:
   email: false
 node_js:
-  - '8'
   - '10'
-  - '11'
+  - '12'
+  - '14'
 script:
   - npm start validate
 after_success:

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "start": "nps",
     "test": "nps test",
     "precommit": "lint-staged && npm start validate",
+    "build": "npm start build",
     "prepublish": "npm start validate"
   },
   "author": "Erik Rasmussen <rasmussenerik@gmail.com> (http://github.com/erikras)",

--- a/src/Field.test.js
+++ b/src/Field.test.js
@@ -996,6 +996,14 @@ describe('Field', () => {
                 </select>
               )}
             </Field>
+            <Field
+              name="selectMultipleWithoutRenderProp"
+              component="select"
+              data-testid="selectMultipleWithoutRenderProp"
+              multiple
+            >
+              <option>{'Option'}</option>
+            </Field>
           </form>
         )}
       </Form>
@@ -1026,6 +1034,11 @@ describe('Field', () => {
       'You must pass `type="select"` prop to your Field(selectMultipleInput) component.\n' +
         "Without it we don't know how to unpack your `value` prop - []."
     )
+    fireEvent.change(getByTestId('selectMultipleWithoutRenderProp'), {
+      target: { value: ['some value'] }
+    })
+    // error not given, since we can deduce that it's a "select"
+    expect(errorSpy).toHaveBeenCalledTimes(3)
     errorSpy.mockRestore()
   })
 

--- a/src/useField.js
+++ b/src/useField.js
@@ -156,7 +156,8 @@ function useField<FormValues: FormValuesShape>(
           const targetType = event.target.type
           const unknown =
             ~['checkbox', 'radio', 'select-multiple'].indexOf(targetType) &&
-            !type
+            !type &&
+            component !== 'select'
 
           const value: any =
             targetType === 'select-multiple' ? state.value : _value


### PR DESCRIPTION
Previously `<Field component="select" multiple>` would generate an error claiming it needs a `type="select"` prop. This was wrong, as we can just see if `component === 'select'` to know.