### PR TITLE
Update  auto-save-selective-debounce to handle clearing inputs

### DIFF
--- a/examples/auto-save-selective-debounce/AutoSave.js
+++ b/examples/auto-save-selective-debounce/AutoSave.js
@@ -2,64 +2,86 @@ import React from "react";
 import { FormSpy } from "react-final-form";
 import diff from "object-diff";
 
+const areObjectsIdentical = (a, b) =>
+  Object.keys(diff(a, b)).length === 0 && Object.keys(diff(b, a)).length === 0;
+
 class AutoSave extends React.Component {
   static defaultProps = {
     debounced: []
   };
   constructor(props) {
     super(props);
-    this.state = { values: props.values, submitting: false };
+
+    this.state = {
+      submitting: false,
+      ...this.splitValues(props.values)
+    };
   }
 
-  componentWillReceiveProps(nextProps) {
-    const { values, debounce, debounced } = nextProps;
+  componentDidUpdate() {
+    const { values, debounce } = this.props;
+    const { debouncedValues, immediateValues } = this.splitValues(values);
+
+    if (!areObjectsIdentical(this.state.immediateValues, immediateValues)) {
+      this.save();
+    }
+
+    if (!areObjectsIdentical(this.state.debouncedValues, debouncedValues)) {
+      if (this.timeout) {
+        clearTimeout(this.timeout);
+      }
+      this.timeout = setTimeout(() => {
+        this.save();
+      }, debounce);
+    }
+  }
+
+  splitValues = values => {
+    const { debounced } = this.props;
+
     const debouncedValues = {};
     const immediateValues = {};
 
     Object.keys(values).forEach(key => {
-      if (~debounced.indexOf(key)) {
+      if (debounced.includes(key)) {
         debouncedValues[key] = values[key];
       } else {
         immediateValues[key] = values[key];
       }
     });
-    if (Object.keys(immediateValues).length) {
-      this.save(immediateValues);
-    }
-    if (Object.keys(debouncedValues).length) {
-      if (this.timeout) {
-        clearTimeout(this.timeout);
-      }
-      this.timeout = setTimeout(() => {
-        this.save(debouncedValues);
-      }, debounce);
-    }
-  }
 
-  save = async values => {
+    return {
+      debouncedValues,
+      immediateValues
+    };
+  };
+
+  save = async () => {
     if (this.promise) {
       await this.promise;
     }
-    const { save } = this.props;
+    const { save, values } = this.props;
 
-    const changedValues = Object.keys(values).reduce((result, key) => {
-      if (values[key] !== this.state.values[key]) {
-        result[key] = values[key];
-      }
-      return result;
-    }, {});
-    if (Object.keys(changedValues).length) {
-      diff(this.state.values);
-      // values have changed
-      this.setState(state => ({
+    const { debouncedValues, immediateValues } = this.splitValues(values);
+
+    this.setState(
+      state => ({
         submitting: true,
-        values: { ...state.values, ...changedValues }
-      }));
-      this.promise = save(changedValues);
-      await this.promise;
-      delete this.promise;
-      this.setState({ submitting: false });
-    }
+        immediateValues: { ...immediateValues },
+        debouncedValues: { ...debouncedValues }
+      }),
+      async () => {
+        this.promise = save({
+          ...this.state.immediateValues,
+          ...this.state.debouncedValues
+        });
+
+        await this.promise;
+        delete this.promise;
+
+        this.setState({ submitting: false });
+      }
+    );
   };
 
   render() {


### PR DESCRIPTION
The actual example of `auto-save-selective-debounce` does not work when the input is cleared.

It does only send the "save" event when the input is changed but not empty.
This is due to the fact that final-form does not send empty values in the `values` object.

<!--

👋 Hey, thanks for your interest in contributing to 🏁 React Final Form!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create an issue to first discuss any significant new
features.

Please try to keep your pull request focused in scope and avoid including
unrelated commits.

After you have submitted your pull request, we’ll try to get back to you as soon
as possible. We may suggest some changes or improvements.

Please format the code before submitting your pull request by running:

```
npm run precommit
```

https://github.com/final-form/react-final-form/blob/master/.github/CONTRIBUTING.md

-->
