### PR TITLE
Move ts-essentials to be a dev dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@
 [![codecov.io](https://codecov.io/gh/final-form/react-final-form/branch/master/graph/badge.svg)](https://codecov.io/gh/final-form/react-final-form)
 [![styled with prettier](https://img.shields.io/badge/styled_with-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
 
+✅ Zero dependencies	(that affect your bundle size)
+
 ✅ Only peer dependencies: React and
 [🏁 Final Form](https://github.com/final-form/final-form#-final-form)
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,6 @@
 [![codecov.io](https://codecov.io/gh/final-form/react-final-form/branch/master/graph/badge.svg)](https://codecov.io/gh/final-form/react-final-form)
 [![styled with prettier](https://img.shields.io/badge/styled_with-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
 
-✅ Zero dependencies
-
 ✅ Only peer dependencies: React and
 [🏁 Final Form](https://github.com/final-form/final-form#-final-form)
 

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "rollup-plugin-uglify": "^6.0.4",
     "tar": "^6.0.1",
     "tslint": "^6.1.0",
+    "ts-essentials": "^6.0.5"
     "typescript": "^3.9.3"
   },
   "peerDependencies": {
@@ -129,7 +130,6 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.10.0",
-    "@scarf/scarf": "^1.0.5",
-    "ts-essentials": "^6.0.5"
+    "@scarf/scarf": "^1.0.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "rollup-plugin-uglify": "^6.0.4",
     "tar": "^6.0.1",
     "tslint": "^6.1.0",
-    "ts-essentials": "^6.0.5"
+    "ts-essentials": "^6.0.5",
     "typescript": "^3.9.3"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Summary
Move `ts-essentials` to be a dev dependency instead of a direct dependency. By including as a dependency, the following message occurs when installing react-final-form:

```
npm ERR! peer dep missing: typescript@>=3.5.0, required by ts-essentials@3.0.5
```

Closes #682 

<!--

👋 Hey, thanks for your interest in contributing to 🏁 React Final Form!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create an issue to first discuss any significant new
features.

Please try to keep your pull request focused in scope and avoid including
unrelated commits.

After you have submitted your pull request, we’ll try to get back to you as soon
as possible. We may suggest some changes or improvements.

Please format the code before submitting your pull request by running:

```
npm run precommit
```

https://github.com/final-form/react-final-form/blob/master/.github/CONTRIBUTING.md

-->
