### PR TITLE
Improve useFormState docs

### DIFF
--- a/docs/api/useFormState.md
+++ b/docs/api/useFormState.md
@@ -6,6 +6,6 @@
 import { useFormState } from 'react-final-form'
 ```
 
-The `useFormState()` hook takes one optional parameter, which matches the exact shape of [`FormSpyProps`](../types/FormSpyProps) (except without the render props). It returns a [`FormSpyRenderProps`](../types/FormSpyRenderProps).
+The `useFormState()` hook takes one optional parameter, which matches the exact shape of [`FormSpyProps`](../types/FormSpyProps) (except without the render props). It returns a [`FormState`](/docs/final-form/types/FormState).
 
 `useFormState()` is used internally inside [`<FormSpy/>`](FormSpy).


### PR DESCRIPTION
useFormState returns a FormState and not a FormSpyRenderProps.

<!--

👋 Hey, thanks for your interest in contributing to 🏁 React Final Form!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create an issue to first discuss any significant new
features.

Please try to keep your pull request focused in scope and avoid including
unrelated commits.

After you have submitted your pull request, we’ll try to get back to you as soon
as possible. We may suggest some changes or improvements.

Please format the code before submitting your pull request by running:

```
npm run precommit
```

https://github.com/final-form/react-final-form/blob/master/.github/CONTRIBUTING.md

-->
