### PR TITLE
Remove any type for input.onChange

### DIFF
--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -28,7 +28,7 @@ interface FieldInputProps<FieldValue, T extends HTMLElement = HTMLElement>
   extends AnyObject {
   name: string;
   onBlur: (event?: React.FocusEvent<T>) => void;
-  onChange: (event: React.ChangeEvent<T> | any) => void;
+  onChange: (event: React.ChangeEvent<T> | FieldValue) => void;
   onFocus: (event?: React.FocusEvent<T>) => void;
   type?: string;
   value: FieldValue;


### PR DESCRIPTION
There two values that can be passed to the `input.onChange`. First is `ChangeEvent` and second is actual value. It would be great if typescript will catch value with incorrect type passed to the `onChange` function.

<!--

👋 Hey, thanks for your interest in contributing to 🏁 React Final Form!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create an issue to first discuss any significant new
features.

Please try to keep your pull request focused in scope and avoid including
unrelated commits.

After you have submitted your pull request, we’ll try to get back to you as soon
as possible. We may suggest some changes or improvements.

Please format the code before submitting your pull request by running:

```
npm run precommit
```

https://github.com/final-form/react-final-form/blob/master/.github/CONTRIBUTING.md

-->
