### PR TITLE
Add note about using array as value

### DIFF
--- a/docs/api/Field.md
+++ b/docs/api/Field.md
@@ -85,4 +85,7 @@ import TextField from '@material-ui/core/TextField'
 </Field>
 ```
 
+
+Note: To use an `array` for the values (with another field type, like a tags-input component), you can do `value={[...props.input.value]}` to avoid "Invalid prop type of 'string' warning"
+
 Now, [let's look at some examples](../examples)!


### PR DESCRIPTION
Just add a note for custom fields using an array, to avoid warning about initial value being a string