### PR TITLE
Allow decorators prop to change identity, but not array contents, without running on every render

### DIFF
--- a/src/ReactFinalForm.js
+++ b/src/ReactFinalForm.js
@@ -112,7 +112,7 @@ function ReactFinalForm<FormValues: FormValuesShape>({
       // don't need to resume validation here; either unmounting, or will re-run this hook with new deps
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [decorators])
+  }, decorators)
 
   // warn about decorator changes
   // istanbul ignore next


### PR DESCRIPTION
I am running into an issue of infinite loops when upgrading from pre-hooks code to hooks based forms.

This allows you to have something like the following where the decorators will change identity on every render, without causing that decorator to be unsubscribed and re-subscribed on every render, which seems like it could be unintentional.

I'm unsure how to write a test for this but would appreciate any guidance!


```tsx
const CustomForm = () => {
    return <Form decorators={[decorator1, decorator2]} />
}
```

Tests are failing for something unrelated? `[test]     Cannot find module '@babel/plugin-transform-react-jsx-source'`