### PR TITLE
fix: stabilize useField public handler identity

### DIFF
--- a/src/useField.js
+++ b/src/useField.js
@@ -130,11 +130,56 @@ function useField<FormValues: FormValuesShape>(
     ]
   )
 
+  const _valueRef = React.useRef(_value)
+  React.useEffect(() => {
+    _valueRef.current = _value
+  })
+
+  const stateRef = React.useRef(state)
+  React.useEffect(() => {
+    stateRef.current = state
+  })
+
+  const nameRef = React.useRef(name)
+  React.useEffect(() => {
+    nameRef.current = name
+  })
+
+  const typeRef = React.useRef(type)
+  React.useEffect(() => {
+    typeRef.current = type
+  })
+
+  const formatOnBlurRef = React.useRef(formatOnBlur)
+  React.useEffect(() => {
+    formatOnBlurRef.current = formatOnBlur
+  })
+
+  const formatRef = React.useRef(format)
+  React.useEffect(() => {
+    formatRef.current = format
+  })
+
+  const parseRef = React.useRef(parse)
+  React.useEffect(() => {
+    parseRef.current = parse
+  })
+
+  const formRef = React.useRef(form)
+  React.useEffect(() => {
+    formRef.current = form
+  })
+
+  const componentRef = React.useRef(component)
+  React.useEffect(() => {
+    componentRef.current = component
+  })
+
   const handlers = {
     onBlur: React.useCallback(
       (event: ?SyntheticFocusEvent<*>) => {
-        state.blur()
-        if (formatOnBlur) {
+        stateRef.current.blur()
+        if (formatOnBlurRef.current) {
           /**
            * Here we must fetch the value directly from Final Form because we cannot
            * trust that our `state` closure has the most recent value. This is a problem
@@ -142,12 +187,11 @@ function useField<FormValues: FormValuesShape>(
            * before calling `onBlur()`, but before the field has had a chance to receive
            * the value update from Final Form.
            */
-          const fieldState: any = form.getFieldState(state.name)
-          state.change(format(fieldState.value, state.name))
+          const fieldState: any = formRef.current.getFieldState(stateRef.current.name)
+          stateRef.current.change(formatRef.current(fieldState.value, stateRef.current.name))
         }
       },
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-      [state.blur, state.name, format, formatOnBlur]
+      []
     ),
     onChange: React.useCallback(
       (event: SyntheticInputEvent<*> | any) => {
@@ -156,17 +200,17 @@ function useField<FormValues: FormValuesShape>(
           const targetType = event.target.type
           const unknown =
             ~['checkbox', 'radio', 'select-multiple'].indexOf(targetType) &&
-            !type &&
-            component !== 'select'
+            !typeRef.current &&
+            componentRef.current !== 'select'
 
           const value: any =
-            targetType === 'select-multiple' ? state.value : _value
+            targetType === 'select-multiple' ? stateRef.current.value : _valueRef.current
 
           if (unknown) {
             console.error(
               `You must pass \`type="${
                 targetType === 'select-multiple' ? 'select' : targetType
-              }"\` prop to your Field(${name}) component.\n` +
+              }"\` prop to your Field(${nameRef.current}) component.\n` +
                 `Without it we don't know how to unpack your \`value\` prop - ${
                   Array.isArray(value) ? `[${value}]` : `"${value}"`
                 }.`
@@ -176,19 +220,17 @@ function useField<FormValues: FormValuesShape>(
 
         const value: any =
           event && event.target
-            ? getValue(event, state.value, _value, isReactNative)
+            ? getValue(event, stateRef.current.value, _valueRef.current, isReactNative)
             : event
-        state.change(parse(value, name))
+        stateRef.current.change(parseRef.current(value, nameRef.current))
       },
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-      [_value, name, parse, state.change, state.value, type]
+      []
     ),
     onFocus: React.useCallback(
       (event: ?SyntheticFocusEvent<*>) => {
-        state.focus()
+        stateRef.current.focus()
       },
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-      [state.focus]
+      []
     )
   }
 

--- a/src/useField.test.js
+++ b/src/useField.test.js
@@ -147,36 +147,306 @@ describe('useField', () => {
     expect(spy.mock.calls[2][0]).toBe(false)
   })
 
-  it('should update input handlers if subscribed field is changed', () => {
+  it('should give same instance of handlers as value changes', () => {
     const spy = jest.fn()
-    const MyFieldListener = ({ name }) => {
-      const { onChange, onFocus, onBlur } = useField(name).input
+    const MyField = ({ name }) => {
+      const { input } = useField(name, { subscription: { value: true } })
+      const { onChange, onFocus, onBlur } = input
       spy(onChange, onFocus, onBlur)
-      return null
+      return <input {...input} />
     }
-    const renderForm = fieldName => (
+    render(
       <Form onSubmit={onSubmitMock}>
         {() => (
           <form>
-            <Field name={fieldName} component="input" data-testid="name" />
-            <MyFieldListener name={fieldName} />
+            <MyField name="myField" />
           </form>
         )}
       </Form>
     )
-    const { rerender } = render(renderForm('first'))
 
-    // All forms without restricted subscriptions render twice at first because they
-    // need to update their validation and touched/modified/visited maps every time
-    // new fields are registered.
     expect(spy).toHaveBeenCalledTimes(2)
-    act(() => {
-      rerender(renderForm('second'))
-    })
+    expect(spy.mock.calls[1][0]).toBe(spy.mock.calls[0][0]) // onChange
+    expect(spy.mock.calls[1][1]).toBe(spy.mock.calls[0][1]) // onFocus
+    expect(spy.mock.calls[1][2]).toBe(spy.mock.calls[0][2]) // onBlur
+
+    const [onChange, onFocus, onBlur] = spy.mock.calls[0]
+    const setValue = value => {
+      act(() => {
+        onFocus()
+        onChange(value)
+        onBlur()
+      })
+    }
+
+    setValue('dog')
+    expect(spy).toHaveBeenCalledTimes(3)
+    expect(spy.mock.calls[2][0]).toBe(spy.mock.calls[1][0]) // onChange
+    expect(spy.mock.calls[2][1]).toBe(spy.mock.calls[1][1]) // onFocus
+    expect(spy.mock.calls[2][2]).toBe(spy.mock.calls[1][2]) // onBlur
+
+    setValue('cat')
     expect(spy).toHaveBeenCalledTimes(4)
-    // the new handlers should be different from ones before changing field name
-    expect(Object.is(spy.mock.calls[1][0], spy.mock.calls[3][0])).toBe(false) // onChange
-    expect(Object.is(spy.mock.calls[1][1], spy.mock.calls[3][1])).toBe(false) // onFocus
-    expect(Object.is(spy.mock.calls[1][2], spy.mock.calls[3][2])).toBe(false) // onBlur
+    expect(spy.mock.calls[3][0]).toBe(spy.mock.calls[2][0]) // onChange
+    expect(spy.mock.calls[3][1]).toBe(spy.mock.calls[2][1]) // onFocus
+    expect(spy.mock.calls[3][2]).toBe(spy.mock.calls[2][2]) // onBlur
+  })
+
+  it('should give same instance of handlers as name changes', () => {
+    const spy = jest.fn()
+    const MyField = ({ name }) => {
+      const { input } = useField(name, { subscription: { value: true } })
+      const { onChange, onFocus, onBlur } = input
+      spy(onChange, onFocus, onBlur)
+      return <input {...input} />
+    }
+    const { rerender } = render(
+      <Form onSubmit={onSubmitMock}>
+        {() => (
+          <form>
+            <MyField name="myField" />
+          </form>
+        )}
+      </Form>
+    )
+
+    expect(spy).toHaveBeenCalledTimes(2)
+    expect(spy.mock.calls[1][0]).toBe(spy.mock.calls[0][0]) // onChange
+    expect(spy.mock.calls[1][1]).toBe(spy.mock.calls[0][1]) // onFocus
+    expect(spy.mock.calls[1][2]).toBe(spy.mock.calls[0][2]) // onBlur
+
+
+    rerender(
+      <Form onSubmit={onSubmitMock}>
+        {() => (
+          <form>
+            <MyField name="dog" />
+          </form>
+        )}
+      </Form>
+    )
+
+    expect(spy).toHaveBeenCalledTimes(4)
+    expect(spy.mock.calls[2][0]).toBe(spy.mock.calls[1][0]) // onChange
+    expect(spy.mock.calls[2][1]).toBe(spy.mock.calls[1][1]) // onFocus
+    expect(spy.mock.calls[2][2]).toBe(spy.mock.calls[1][2]) // onBlur
+    expect(spy.mock.calls[3][0]).toBe(spy.mock.calls[2][0]) // onChange
+    expect(spy.mock.calls[3][1]).toBe(spy.mock.calls[2][1]) // onFocus
+    expect(spy.mock.calls[3][2]).toBe(spy.mock.calls[2][2]) // onBlur
+  })
+
+  it('should give same instance of handlers as type changes', () => {
+    const spy = jest.fn()
+    const MyField = ({ name, type }) => {
+      const { input } = useField(name, { subscription: { value: true }, type })
+      const { onChange, onFocus, onBlur } = input
+      spy(onChange, onFocus, onBlur)
+      return <input {...input} />
+    }
+    const { rerender } = render(
+      <Form onSubmit={onSubmitMock}>
+        {() => (
+          <form>
+            <MyField name="myField" />
+          </form>
+        )}
+      </Form>
+    )
+
+    expect(spy).toHaveBeenCalledTimes(2)
+    expect(spy.mock.calls[1][0]).toBe(spy.mock.calls[0][0]) // onChange
+    expect(spy.mock.calls[1][1]).toBe(spy.mock.calls[0][1]) // onFocus
+    expect(spy.mock.calls[1][2]).toBe(spy.mock.calls[0][2]) // onBlur
+
+
+    rerender(
+      <Form onSubmit={onSubmitMock}>
+        {() => (
+          <form>
+            <MyField name="dog" type="search"/>
+          </form>
+        )}
+      </Form>
+    )
+
+    expect(spy).toHaveBeenCalledTimes(4)
+    expect(spy.mock.calls[2][0]).toBe(spy.mock.calls[1][0]) // onChange
+    expect(spy.mock.calls[2][1]).toBe(spy.mock.calls[1][1]) // onFocus
+    expect(spy.mock.calls[2][2]).toBe(spy.mock.calls[1][2]) // onBlur
+    expect(spy.mock.calls[3][0]).toBe(spy.mock.calls[2][0]) // onChange
+    expect(spy.mock.calls[3][1]).toBe(spy.mock.calls[2][1]) // onFocus
+    expect(spy.mock.calls[3][2]).toBe(spy.mock.calls[2][2]) // onBlur
+  })
+
+  it('should give same instance of handlers as formatOnBlur changes', () => {
+    const spy = jest.fn()
+    const MyField = ({ name, formatOnBlur }) => {
+      const { input } = useField(name, { subscription: { value: true }, formatOnBlur })
+      const { onChange, onFocus, onBlur } = input
+      spy(onChange, onFocus, onBlur)
+      return <input {...input} />
+    }
+    const { rerender } = render(
+      <Form onSubmit={onSubmitMock}>
+        {() => (
+          <form>
+            <MyField name="myField" />
+          </form>
+        )}
+      </Form>
+    )
+
+    expect(spy).toHaveBeenCalledTimes(2)
+    expect(spy.mock.calls[1][0]).toBe(spy.mock.calls[0][0]) // onChange
+    expect(spy.mock.calls[1][1]).toBe(spy.mock.calls[0][1]) // onFocus
+    expect(spy.mock.calls[1][2]).toBe(spy.mock.calls[0][2]) // onBlur
+
+
+    rerender(
+      <Form onSubmit={onSubmitMock}>
+        {() => (
+          <form>
+            <MyField name="dog" formatOnBlur />
+          </form>
+        )}
+      </Form>
+    )
+
+    expect(spy).toHaveBeenCalledTimes(4)
+    expect(spy.mock.calls[2][0]).toBe(spy.mock.calls[1][0]) // onChange
+    expect(spy.mock.calls[2][1]).toBe(spy.mock.calls[1][1]) // onFocus
+    expect(spy.mock.calls[2][2]).toBe(spy.mock.calls[1][2]) // onBlur
+    expect(spy.mock.calls[3][0]).toBe(spy.mock.calls[2][0]) // onChange
+    expect(spy.mock.calls[3][1]).toBe(spy.mock.calls[2][1]) // onFocus
+    expect(spy.mock.calls[3][2]).toBe(spy.mock.calls[2][2]) // onBlur
+  })
+
+  it('should give same instance of handlers as parse changes', () => {
+    const spy = jest.fn()
+    const MyField = ({ name, parse }) => {
+      const { input } = useField(name, { subscription: { value: true }, parse })
+      const { onChange, onFocus, onBlur } = input
+      spy(onChange, onFocus, onBlur)
+      return <input {...input} />
+    }
+    const { rerender } = render(
+      <Form onSubmit={onSubmitMock}>
+        {() => (
+          <form>
+            <MyField name="myField" />
+          </form>
+        )}
+      </Form>
+    )
+
+    expect(spy).toHaveBeenCalledTimes(2)
+    expect(spy.mock.calls[1][0]).toBe(spy.mock.calls[0][0]) // onChange
+    expect(spy.mock.calls[1][1]).toBe(spy.mock.calls[0][1]) // onFocus
+    expect(spy.mock.calls[1][2]).toBe(spy.mock.calls[0][2]) // onBlur
+
+
+    rerender(
+      <Form onSubmit={onSubmitMock}>
+        {() => (
+          <form>
+            <MyField name="dog" parse={(x) => x} />
+          </form>
+        )}
+      </Form>
+    )
+
+    expect(spy).toHaveBeenCalledTimes(4)
+    expect(spy.mock.calls[2][0]).toBe(spy.mock.calls[1][0]) // onChange
+    expect(spy.mock.calls[2][1]).toBe(spy.mock.calls[1][1]) // onFocus
+    expect(spy.mock.calls[2][2]).toBe(spy.mock.calls[1][2]) // onBlur
+    expect(spy.mock.calls[3][0]).toBe(spy.mock.calls[2][0]) // onChange
+    expect(spy.mock.calls[3][1]).toBe(spy.mock.calls[2][1]) // onFocus
+    expect(spy.mock.calls[3][2]).toBe(spy.mock.calls[2][2]) // onBlur
+  })
+
+  it('should give same instance of handlers as format changes', () => {
+    const spy = jest.fn()
+    const MyField = ({ name, format }) => {
+      const { input } = useField(name, { subscription: { value: true }, format })
+      const { onChange, onFocus, onBlur } = input
+      spy(onChange, onFocus, onBlur)
+      return <input {...input} />
+    }
+    const { rerender } = render(
+      <Form onSubmit={onSubmitMock}>
+        {() => (
+          <form>
+            <MyField name="myField" />
+          </form>
+        )}
+      </Form>
+    )
+
+    expect(spy).toHaveBeenCalledTimes(2)
+    expect(spy.mock.calls[1][0]).toBe(spy.mock.calls[0][0]) // onChange
+    expect(spy.mock.calls[1][1]).toBe(spy.mock.calls[0][1]) // onFocus
+    expect(spy.mock.calls[1][2]).toBe(spy.mock.calls[0][2]) // onBlur
+
+
+    rerender(
+      <Form onSubmit={onSubmitMock}>
+        {() => (
+          <form>
+            <MyField name="dog" format={(x) => x} />
+          </form>
+        )}
+      </Form>
+    )
+
+    expect(spy).toHaveBeenCalledTimes(4)
+    expect(spy.mock.calls[2][0]).toBe(spy.mock.calls[1][0]) // onChange
+    expect(spy.mock.calls[2][1]).toBe(spy.mock.calls[1][1]) // onFocus
+    expect(spy.mock.calls[2][2]).toBe(spy.mock.calls[1][2]) // onBlur
+    expect(spy.mock.calls[3][0]).toBe(spy.mock.calls[2][0]) // onChange
+    expect(spy.mock.calls[3][1]).toBe(spy.mock.calls[2][1]) // onFocus
+    expect(spy.mock.calls[3][2]).toBe(spy.mock.calls[2][2]) // onBlur
+  })
+
+  it('should give same instance of handlers as component changes', () => {
+    const spy = jest.fn()
+    const MyField = ({ name, component }) => {
+      const { input } = useField(name, { subscription: { value: true }, component })
+      const { onChange, onFocus, onBlur } = input
+      spy(onChange, onFocus, onBlur)
+      return <input {...input} />
+    }
+    const { rerender } = render(
+      <Form onSubmit={onSubmitMock}>
+        {() => (
+          <form>
+            <MyField name="myField" />
+          </form>
+        )}
+      </Form>
+    )
+
+    expect(spy).toHaveBeenCalledTimes(2)
+    expect(spy.mock.calls[1][0]).toBe(spy.mock.calls[0][0]) // onChange
+    expect(spy.mock.calls[1][1]).toBe(spy.mock.calls[0][1]) // onFocus
+    expect(spy.mock.calls[1][2]).toBe(spy.mock.calls[0][2]) // onBlur
+
+
+    rerender(
+      <Form onSubmit={onSubmitMock}>
+        {() => (
+          <form>
+            <MyField name="dog" component="select" />
+          </form>
+        )}
+      </Form>
+    )
+
+    expect(spy).toHaveBeenCalledTimes(4)
+    expect(spy.mock.calls[2][0]).toBe(spy.mock.calls[1][0]) // onChange
+    expect(spy.mock.calls[2][1]).toBe(spy.mock.calls[1][1]) // onFocus
+    expect(spy.mock.calls[2][2]).toBe(spy.mock.calls[1][2]) // onBlur
+    expect(spy.mock.calls[3][0]).toBe(spy.mock.calls[2][0]) // onChange
+    expect(spy.mock.calls[3][1]).toBe(spy.mock.calls[2][1]) // onFocus
+    expect(spy.mock.calls[3][2]).toBe(spy.mock.calls[2][2]) // onBlur
   })
 })


### PR DESCRIPTION
`useField` public handlers like `onFocus`, `onChange`, `onBlur` are changing their identities based on various internal variables and externally available props/(config parts) like `value`, `name`, `parse` etc...

I am suggesting that public handlers should not be subject to identity change at all, so that consumers can rely on those without jumping through hoops with `useRef` as in https://reactjs.org/docs/hooks-faq.html#what-can-i-do-if-my-effect-dependencies-change-too-often.

As a consequence after this change consumer code relying on this behavior might break, hence this is a BREAKING CHANGE

Closes #816
