### PR TITLE
Improved typing for the ability to convert types when using parse/format

### DIFF
--- a/src/FormSpy.test.js
+++ b/src/FormSpy.test.js
@@ -341,7 +341,7 @@ describe('FormSpy', () => {
             <FormSpy
               subscription={{ dirty: true, values: true }}
               onChange={spy}
-              render={render}
+              render={renderSpy}
             />
           </form>
         )}

--- a/src/ReactFinalForm.js
+++ b/src/ReactFinalForm.js
@@ -42,7 +42,7 @@ export const all: FormSubscription = formSubscriptionItems.reduce(
 
 function ReactFinalForm<FormValues: FormValuesShape>({
   debug,
-  decorators,
+  decorators = [],
   destroyOnUnregister,
   form: alternateFormApi,
   initialValues,

--- a/typescript/Field.test.tsx
+++ b/typescript/Field.test.tsx
@@ -1,6 +1,8 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import * as React from 'react';
-import { FieldRenderProps } from 'react-final-form';
+import { Field, FieldRenderProps } from 'react-final-form';
+
+const NumberInput: React.FC<{ value?: number }> = () => null;
 
 function FormText1({ input }: FieldRenderProps<string, HTMLInputElement>) {
   // renders OK because of the used generic
@@ -11,4 +13,23 @@ function FormText2({ input }: FieldRenderProps<string, HTMLInputElement>) {
   // doesnt type check because we can't pass event handlers for `HTMLInputElement` to a <select/> component
   // $ExpectError
   return <select {...input} />;
+}
+
+function FieldNumberValue() {
+  return (
+    <Field<number, FieldRenderProps<number>> name="numberField">
+      {({ input }) => <NumberInput value={input.value} />}
+    </Field>
+  );
+}
+
+function FieldNumberInputValue() {
+  return (
+    <Field<string, FieldRenderProps<string, HTMLElement, number>>
+      name="numberField"
+      parse={(value: number) => String(value)}
+    >
+      {({ input }) => <NumberInput value={input.value} />}
+    </Field>
+  );
 }

--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -12,7 +12,10 @@ import {
 
 type SupportedInputs = 'input' | 'select' | 'textarea';
 
-export interface ReactContext<FormValues = Record<string, any>, InitialFormValues = Partial<FormValues>> {
+export interface ReactContext<
+  FormValues = Record<string, any>,
+  InitialFormValues = Partial<FormValues>
+> {
   reactFinalForm: FormApi<FormValues, InitialFormValues>;
 }
 
@@ -42,15 +45,18 @@ interface AnyObject {
 
 export interface FieldRenderProps<
   FieldValue,
-  T extends HTMLElement = HTMLElement
+  T extends HTMLElement = HTMLElement,
+  InputValue = FieldValue
 > {
-  input: FieldInputProps<FieldValue, T>;
+  input: FieldInputProps<InputValue, T>;
   meta: FieldMetaState<FieldValue>;
   [otherProp: string]: any;
 }
 
-export interface FormRenderProps<FormValues = Record<string, any>, InitialFormValues = Partial<FormValues>>
-  extends FormState<FormValues, InitialFormValues>,
+export interface FormRenderProps<
+  FormValues = Record<string, any>,
+  InitialFormValues = Partial<FormValues>
+> extends FormState<FormValues, InitialFormValues>,
     RenderableProps<FormRenderProps<FormValues>> {
   form: FormApi<FormValues>;
   handleSubmit: (
@@ -60,8 +66,10 @@ export interface FormRenderProps<FormValues = Record<string, any>, InitialFormVa
   ) => Promise<AnyObject | undefined> | undefined;
 }
 
-export interface FormSpyRenderProps<FormValues = Record<string, any>, InitialFormValues = Partial<FormValues>>
-  extends FormState<FormValues, InitialFormValues> {
+export interface FormSpyRenderProps<
+  FormValues = Record<string, any>,
+  InitialFormValues = Partial<FormValues>
+> extends FormState<FormValues, InitialFormValues> {
   form: FormApi<FormValues, InitialFormValues>;
 }
 
@@ -71,8 +79,10 @@ export interface RenderableProps<T> {
   render?: (props: T) => React.ReactNode;
 }
 
-export interface FormProps<FormValues = Record<string, any>, InitialFormValues = Partial<FormValues>>
-  extends Config<FormValues, InitialFormValues>,
+export interface FormProps<
+  FormValues = Record<string, any>,
+  InitialFormValues = Partial<FormValues>
+> extends Config<FormValues, InitialFormValues>,
     RenderableProps<FormRenderProps<FormValues, InitialFormValues>> {
   subscription?: FormSubscription;
   decorators?: Array<Decorator<FormValues, InitialFormValues>>;
@@ -81,18 +91,18 @@ export interface FormProps<FormValues = Record<string, any>, InitialFormValues =
   [otherProp: string]: any;
 }
 
-export interface UseFieldConfig<FieldValue> {
+export interface UseFieldConfig<FieldValue, InputValue = any> {
   afterSubmit?: () => void;
   allowNull?: boolean;
   beforeSubmit?: () => void | boolean;
   data?: AnyObject;
   defaultValue?: FieldValue;
-  format?: (value: FieldValue, name: string) => any;
+  format?: (value: FieldValue, name: string) => InputValue;
   formatOnBlur?: boolean;
   initialValue?: FieldValue;
   isEqual?: (a: any, b: any) => boolean;
   multiple?: boolean;
-  parse?: (value: any, name: string) => FieldValue;
+  parse?: (value: InputValue, name: string) => FieldValue;
   subscription?: FieldSubscription;
   type?: string;
   validate?: FieldValidator<FieldValue>;
@@ -102,49 +112,75 @@ export interface UseFieldConfig<FieldValue> {
 
 export interface FieldProps<
   FieldValue,
-  RP extends FieldRenderProps<FieldValue, T>,
-  T extends HTMLElement = HTMLElement
-> extends UseFieldConfig<FieldValue>, RenderableProps<RP> {
+  RP extends FieldRenderProps<FieldValue, T, InputValue>,
+  T extends HTMLElement = HTMLElement,
+  InputValue = any
+> extends UseFieldConfig<FieldValue, InputValue>,
+    RenderableProps<RP> {
   name: string;
   [otherProp: string]: any;
 }
 
-export interface UseFormStateParams<FormValues = Record<string, any>, InitialFormValues = Partial<FormValues>> {
+export interface UseFormStateParams<
+  FormValues = Record<string, any>,
+  InitialFormValues = Partial<FormValues>
+> {
   onChange?: (formState: FormState<FormValues, InitialFormValues>) => void;
   subscription?: FormSubscription;
 }
 
-export interface FormSpyProps<FormValues = Record<string, any>, InitialFormValues = Partial<FormValues>>
-  extends UseFormStateParams<FormValues, InitialFormValues>,
+export interface FormSpyProps<
+  FormValues = Record<string, any>,
+  InitialFormValues = Partial<FormValues>
+> extends UseFormStateParams<FormValues, InitialFormValues>,
     RenderableProps<FormSpyRenderProps<FormValues, InitialFormValues>> {}
 
 export const Field: <
   FieldValue = any,
-  RP extends FieldRenderProps<FieldValue, T> = FieldRenderProps<
+  RP extends FieldRenderProps<FieldValue, T, InputValue> = FieldRenderProps<
     FieldValue,
-    HTMLElement
+    HTMLElement,
+    any
   >,
-  T extends HTMLElement = HTMLElement
+  T extends HTMLElement = HTMLElement,
+  InputValue = any
 >(
-  props: FieldProps<FieldValue, RP, T>
+  props: FieldProps<FieldValue, RP, T, InputValue>
 ) => React.ReactElement;
-export const Form: <FormValues = Record<string, any>, InitialFormValues = Partial<FormValues>>(
+export const Form: <
+  FormValues = Record<string, any>,
+  InitialFormValues = Partial<FormValues>
+>(
   props: FormProps<FormValues, InitialFormValues>
 ) => React.ReactElement;
-export const FormSpy: <FormValues = Record<string, any>, InitialFormValues = Partial<FormValues>>(
+export const FormSpy: <
+  FormValues = Record<string, any>,
+  InitialFormValues = Partial<FormValues>
+>(
   props: FormSpyProps<FormValues, InitialFormValues>
 ) => React.ReactElement;
-export function useField<FieldValue = any, T extends HTMLElement = HTMLElement>(
+export function useField<
+  FieldValue = any,
+  T extends HTMLElement = HTMLElement,
+  InputValue = any
+>(
   name: string,
-  config?: UseFieldConfig<FieldValue>
-): FieldRenderProps<FieldValue, T>;
-export function useForm<FormValues = Record<string, any>, InitialFormValues = Partial<FormValues>>(
-  componentName?: string
-): FormApi<FormValues, InitialFormValues>;
-export function useFormState<FormValues = Record<string, any>, InitialFormValues = Partial<FormValues>>(
+  config?: UseFieldConfig<FieldValue, InputValue>
+): FieldRenderProps<FieldValue, T, InputValue>;
+export function useForm<
+  FormValues = Record<string, any>,
+  InitialFormValues = Partial<FormValues>
+>(componentName?: string): FormApi<FormValues, InitialFormValues>;
+export function useFormState<
+  FormValues = Record<string, any>,
+  InitialFormValues = Partial<FormValues>
+>(
   params?: UseFormStateParams<FormValues, InitialFormValues>
 ): FormState<FormValues, InitialFormValues>;
-export function withTypes<FormValues = Record<string, any>, InitialFormValues = Partial<FormValues>>(): {
+export function withTypes<
+  FormValues = Record<string, any>,
+  InitialFormValues = Partial<FormValues>
+>(): {
   Form: React.FC<FormProps<FormValues, InitialFormValues>>;
   FormSpy: React.FC<FormSpyProps<FormValues, InitialFormValues>>;
 };

--- a/typescript/useField.test.tsx
+++ b/typescript/useField.test.tsx
@@ -1,0 +1,18 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import * as React from 'react';
+import { useField } from 'react-final-form';
+
+const NumberInput: React.FC<{ value?: number }> = () => null;
+
+function NumberFieldValue() {
+  const { input } = useField<number>('numberField');
+  return <NumberInput value={input.value} />;
+}
+
+function NumberInputValue() {
+  const { input } = useField('numberField', {
+    format: (value: string) => Number(value),
+    parse: (value: number) => String(value)
+  });
+  return <NumberInput value={input.value} />;
+}


### PR DESCRIPTION
Sometimes it is required that in `FieldState.value` and `input.value` were of different types. This is possible through the use of the parse/format props in Field or in useField config.

But when using typescript type conversion is not performed. `input.value` is always typed as the value from FieldState

This pull request corrects the current typing.

Closes #929


