### PR TITLE
feat: 🔄 use StrictOmit

### DIFF
--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -9,6 +9,7 @@ import {
   FieldSubscription,
   FieldValidator,
 } from "final-form";
+import { StrictOmit } from "ts-essentials";
 
 type SupportedInputs = "input" | "select" | "textarea";
 
@@ -19,12 +20,9 @@ export interface ReactContext<
   reactFinalForm: FormApi<FormValues, InitialFormValues>;
 }
 
-export type FieldMetaState<FieldValue> = Pick<
+export type FieldMetaState<FieldValue> = StrictOmit<
   FieldState<FieldValue>,
-  Exclude<
-    keyof FieldState<FieldValue>,
-    "blur" | "change" | "focus" | "name" | "value"
-  >
+  "blur" | "change" | "focus" | "name" | "value"
 >;
 
 interface FieldInputProps<FieldValue, T extends HTMLElement = HTMLElement>


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to 🏁 React Final Form!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create an issue to first discuss any significant new
features.

Please try to keep your pull request focused in scope and avoid including
unrelated commits.

After you have submitted your pull request, we’ll try to get back to you as soon
as possible. We may suggest some changes or improvements.

Please format the code before submitting your pull request by running:

```
npm run precommit
```

https://github.com/final-form/react-final-form/blob/master/.github/CONTRIBUTING.md

-->

Hey 👋

I've seen that `Omit` usage was removed here – https://github.com/final-form/react-final-form/pull/589

I was interested whether you want to use builtin `Omit` from `typescript` or use `StrictOmit` from `ts-essentials` which also checks if the property is in the object (before removing it)

If you prefer `Omit` to not use `ts-essentials`, I will adapt the PR to be able to get rid of `ts-essentials`

Refers to https://github.com/final-form/react-final-form/issues/765
