### PR TITLE
fix: submitting persisting true state

### DIFF
--- a/src/ReactFinalForm.js
+++ b/src/ReactFinalForm.js
@@ -86,7 +86,8 @@ function ReactFinalForm<FormValues: FormValuesShape>({
 
   // save a copy of state that can break through the closure
   // on the shallowEqual() line below.
-  const stateRef = useLatest<FormState<FormValues>>(state);
+  const stateRef = React.useRef<FormState>(state);
+  stateRef.current = state;
 
   React.useEffect(() => {
     // We have rendered, so all fields are now registered, so we can unpause validation


### PR DESCRIPTION
This issue is connected with this PR https://github.com/final-form/react-final-form/pull/513/files

When onSubmit returns without delay update batches and re-render never happens.

This will fix issue with `subscription` and `submitting` where `submitting` will stay `true` even thought the updated value should be `false` 

Closes [#875](https://github.com/final-form/react-final-form/issues/875), [#903](https://github.com/final-form/react-final-form/issues/903)
