### PR TITLE
Use parse instead of format when calculating checked

### DIFF
--- a/src/Field.test.js
+++ b/src/Field.test.js
@@ -1249,3 +1249,91 @@ describe("Field", () => {
     console.error.mockRestore();
   });
 });
+
+it("should support using format/parse with radio controls", () => {
+  const format = (value) => value && value.toString();
+  const parse = (value) => value && parseInt(value, 10);
+
+  const { getByTestId } = render(
+    <Form onSubmit={onSubmitMock} initialValues={{ number: 20 }}>
+      {({ handleSubmit }) => (
+        <form onSubmit={handleSubmit}>
+          <Field
+            name="number"
+            component="input"
+            type="radio"
+            value={10}
+            data-testid="ten"
+            parse={parse}
+            format={format}
+          />
+          <Field
+            name="number"
+            component="input"
+            type="radio"
+            value={20}
+            data-testid="twenty"
+            parse={parse}
+            format={format}
+          />
+          <Field
+            name="number"
+            component="input"
+            type="radio"
+            value={30}
+            data-testid="thirty"
+            parse={parse}
+            format={format}
+          />
+        </form>
+      )}
+    </Form>,
+  );
+  expect(getByTestId("ten").checked).toBe(false);
+  expect(getByTestId("twenty").checked).toBe(true);
+  expect(getByTestId("thirty").checked).toBe(false);
+});
+
+it("should support using format/parse with checkbox controls", () => {
+  const format = (value) => value && value.map((x) => x.toString());
+  const parse = (value) => value && value.map((x) => parseInt(x, 10));
+
+  const { getByTestId } = render(
+    <Form onSubmit={onSubmitMock} initialValues={{ number: [20, 30] }}>
+      {({ handleSubmit }) => (
+        <form onSubmit={handleSubmit}>
+          <Field
+            name="number"
+            component="input"
+            type="checkbox"
+            value={10}
+            data-testid="ten"
+            parse={parse}
+            format={format}
+          />
+          <Field
+            name="number"
+            component="input"
+            type="checkbox"
+            value={20}
+            data-testid="twenty"
+            parse={parse}
+            format={format}
+          />
+          <Field
+            name="number"
+            component="input"
+            type="checkbox"
+            value={30}
+            data-testid="thirty"
+            parse={parse}
+            format={format}
+          />
+        </form>
+      )}
+    </Form>,
+  );
+  expect(getByTestId("ten").checked).toBe(false);
+  expect(getByTestId("twenty").checked).toBe(true);
+  expect(getByTestId("thirty").checked).toBe(true);
+});

--- a/src/useField.js
+++ b/src/useField.js
@@ -161,14 +161,14 @@ function useField<FormValues: FormValuesShape>(
     get checked() {
       let value = state.value;
       if (type === "checkbox") {
-        value = format(value, name);
+        value = parse(value, name);
         if (_value === undefined) {
           return !!value;
         } else {
           return !!(Array.isArray(value) && ~value.indexOf(_value));
         }
       } else if (type === "radio") {
-        return format(value, name) === _value;
+        return parse(value, name) === _value;
       }
       return undefined;
     },


### PR DESCRIPTION
This may be an incorrect assumption, but it seems like the getter for `checked` should be using `parse`, not `format` when comparing values. In addition to fixing an issue I was experiencing, the TypeScript definitions suggest this should be the intended behavior as well as `parse` returns `FieldValue` and `state.config` is of the type `FieldValue`.

I added a couple of tests to prevent future regressions – please let me know if there's anything else I should do to get this to a state where you'd be comfortable accepting the patch.

Thanks for the great library!