### PR TITLE
Add React 18 to peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
   },
   "peerDependencies": {
     "final-form": "^4.20.4",
-    "react": "^16.8.0 || ^17.0.0"
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
   },
   "lint-staged": {
     "*.{js*,ts*,json,md,css}": [


### PR DESCRIPTION
React 18 has been released yesterday.

I didn't test React Final Form with new concurrent features, but according to the docs React 18 behaves like 17 if you don't use them. For this case forms in my apps work fine. So I think we can start by updating the peer dependency to avoid package managers warnings.