### PR TITLE
Fix departing rerender counters

### DIFF
--- a/examples/subscriptions/Styles.js
+++ b/examples/subscriptions/Styles.js
@@ -53,6 +53,7 @@ export default styled.div`
   }
 
   form {
+    position: relative;
     max-width: 500px;
     margin: 10px auto;
     border: 1px solid #ccc;


### PR DESCRIPTION
Right now forms RenderCounts move to top right corner of window. Added position: relative to form for catching counter in form
Now:
![image](https://user-images.githubusercontent.com/14909082/185207316-72541de7-c027-45ea-9218-d1b3bec6809e.png)

Fixed:
![image](https://user-images.githubusercontent.com/14909082/185207337-310a1acf-05a9-41b7-91cc-405149044768.png)


