### PR TITLE
Fixed isEqual register initalization

### DIFF
--- a/src/useField.js
+++ b/src/useField.js
@@ -85,7 +85,7 @@ function useField<FormValues: FormValuesShape>(
       defaultValue,
       getValidator: () => configRef.current.validate,
       initialValue,
-      isEqual: (a, b) => (configRef.current.isEqual || defaultIsEqual)(a, b),
+      isEqual: configRef.current.isEqual,
       silent,
       validateFields,
     });


### PR DESCRIPTION
Remove the unnecessary `isEqual` function definition. This was necessary because https://github.com/final-form/react-final-form/issues/1032 is fixed by updating the field `isEqual` every time `registerField` is called. This fix relies on the fact that `isEqual` is only defined when necessary