### PR TITLE
fix(useField): Fix no re-render on initialValue change

### DIFF
--- a/src/useField.js
+++ b/src/useField.js
@@ -112,11 +112,14 @@ function useField<FormValues: FormValuesShape>(
 
   React.useEffect(
     () =>
-      register((state) => {
+      register((newState) => {
         if (firstRender.current) {
           firstRender.current = false;
+          if(state.initial != newState.initial){
+            setState(newState);
+          }
         } else {
-          setState(state);
+          setState(newState);
         }
       }, false),
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/useField.test.js
+++ b/src/useField.test.js
@@ -455,4 +455,27 @@ describe("useField", () => {
     expect(spy.mock.calls[3][1]).toBe(spy.mock.calls[2][1]); // onFocus
     expect(spy.mock.calls[3][2]).toBe(spy.mock.calls[2][2]); // onBlur
   });
+
+  it("should listen to initial value 2", () => {
+    const MyFieldListener = () => {
+      const isFirstRender = React.useRef(true)
+      const { input, meta } = useField("name");
+      if(!isFirstRender.current){
+        expect(meta.initial).toBe("test");
+        // expect(input.value).toBe("test");
+      }
+      isFirstRender.current = false
+      return null;
+    };
+    render(
+      <Form onSubmit={onSubmitMock}>
+        {() => (
+          <form>
+            <MyFieldListener />
+            <Field name="name" component="input" data-testid="name" initialValue="test"/>
+          </form>
+        )}
+      </Form>,
+    );
+  });
 });


### PR DESCRIPTION
Currently useField doesn't retriggers properly if the initialValue is changed (Added test scenario). 
Added explicit check for initial value change to prevent deepEqual overheads.