### PR TITLE
Add React 19 to peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
   },
   "peerDependencies": {
     "final-form": "^4.20.4",
-    "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "lint-staged": {
     "*.{js*,ts*,json,md,css}": [


### PR DESCRIPTION
A simple addition of React 19 to peer dependencies, which should resolve the peer dependency warnings.