### PR TITLE
Fix #1055: Remove spreading of lazy state in FormSpy renderProps

### DIFF
--- a/src/FormSpy.tsx
+++ b/src/FormSpy.tsx
@@ -16,7 +16,6 @@ function FormSpy<FormValues = Record<string, any>>({
   }
 
   const renderProps: FormSpyRenderProps<FormValues> = {
-    ...state,
     form: {
       ...reactFinalForm,
       reset: (eventOrValues?: any) => {


### PR DESCRIPTION
**Issue:** FormSpy was throwing "Cannot set property active" error when using subscription to 'active' field in v7.0.0.

**Root cause:** In the TypeScript migration (commit 875f4ce), the FormSpy component started spreading the lazy state object into renderProps. The lazy state object has getter-only properties defined by addLazyFormState(), which makes them read-only. Spreading these properties into a new object causes JavaScript to attempt to set them, which fails because they have no setter.

**Fix:** Remove `...state` from renderProps. The state is already passed separately to renderComponent() as lazyProps parameter, which correctly handles the getter-only properties using Object.defineProperties().

**Test:** Added test case that verifies FormSpy with subscription to 'active' and 'values' renders without error and can access these properties correctly.

**Closes** #1055

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an error occurring when FormSpy subscribes to the active property, ensuring proper handling of form field focus state.

* **Refactoring**
  * Simplified FormSpy's render props structure to explicitly expose only the form property, reducing unnecessary field exposure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->