### PR TITLE
Fix: Support type='select' for multiple select defaulting to []

### DIFF
--- a/src/useField.test.js
+++ b/src/useField.test.js
@@ -598,4 +598,81 @@ describe("useField", () => {
     expect(renderSpy.mock.calls[0][0]).toBe("Apple");
     expect(getByTestId("array").value).toBe("Apple");
   });
+
+  it("should default undefined value to [] for select multiple with type prop (fix react-final-form-arrays #185)", () => {
+    const renderSpy = jest.fn();
+    const MySelectField = () => {
+      const { input } = useField("scopes", { type: "select", multiple: true });
+      renderSpy(input.value);
+      return (
+        <select {...input} multiple data-testid="select">
+          <option value="read">Read</option>
+          <option value="write">Write</option>
+        </select>
+      );
+    };
+    render(
+      <Form onSubmit={onSubmitMock}>
+        {() => (
+          <form>
+            <MySelectField />
+          </form>
+        )}
+      </Form>,
+    );
+    // When no initial value is provided, should default to [] not undefined
+    // This prevents React warning: "The `value` prop supplied to <select> must be an array if `multiple` is true"
+    expect(renderSpy.mock.calls[0][0]).toEqual([]);
+  });
+
+  it("should default undefined value to [] for select multiple with component prop", () => {
+    const renderSpy = jest.fn();
+    const MySelectField = () => {
+      const { input } = useField("scopes", { component: "select", multiple: true });
+      renderSpy(input.value);
+      return (
+        <select {...input} multiple data-testid="select">
+          <option value="read">Read</option>
+          <option value="write">Write</option>
+        </select>
+      );
+    };
+    render(
+      <Form onSubmit={onSubmitMock}>
+        {() => (
+          <form>
+            <MySelectField />
+          </form>
+        )}
+      </Form>,
+    );
+    // When no initial value is provided, should default to [] not undefined
+    // This prevents React warning: "The `value` prop supplied to <select> must be an array if `multiple` is true"
+    expect(renderSpy.mock.calls[0][0]).toEqual([]);
+  });
+
+  it("should ensure select multiple value is always an array", () => {
+    const renderSpy = jest.fn();
+    const MySelectField = () => {
+      const { input } = useField("scopes", { type: "select", multiple: true });
+      renderSpy(input.value);
+      return (
+        <select {...input} multiple data-testid="select">
+          <option value="read">Read</option>
+          <option value="write">Write</option>
+        </select>
+      );
+    };
+    render(
+      <Form onSubmit={onSubmitMock} initialValues={{ scopes: null }}>
+        {() => (
+          <form>
+            <MySelectField />
+          </form>
+        )}
+      </Form>,
+    );
+    // Even if the form value is null/undefined, input.value should be []
+    expect(Array.isArray(renderSpy.mock.calls[0][0])).toBe(true);
+  });
 });

--- a/src/useField.ts
+++ b/src/useField.ts
@@ -122,7 +122,7 @@ function useField<
     // Use Form initialValues if available, otherwise use field initialValue
     let initialStateValue = formInitialValue !== undefined ? formInitialValue : initialValue;
     
-    if (component === "select" && multiple && initialStateValue === undefined) {
+    if ((component === "select" || type === "select") && multiple && initialStateValue === undefined) {
       initialStateValue = [];
     }
 
@@ -191,7 +191,7 @@ function useField<
       }
     }
 
-    if (component === "select" && multiple) {
+    if ((component === "select" || type === "select") && multiple) {
       return Array.isArray(value) ? value : [];
     }
     // For checkboxes and radios, the `value` prop on the input element itself


### PR DESCRIPTION
## Problem
React-final-form-arrays issue #185 reported this error after upgrading to v4.0.0:
```
The \`value\` prop supplied to <select> must be an array if \`multiple\` is true.
```

When users pass `type="select" multiple={true}` to a Field, the value wasn't being defaulted to `[]`, causing React to complain.

## Root Cause
The code in `useField.ts` only checked `component === "select"` to determine when to default undefined values to `[]`. However, many users pass `type="select"` instead of `component="select"`.

## Solution
Update both locations where select multiple is handled:
1. **Line 125**: Initialize undefined values to `[]` when `(component === "select" || type === "select") && multiple`
2. **Line 197**: Ensure value is always an array in `getInputValue()` when `(component === "select" || type === "select") && multiple`

## Testing
- ✅ Added 3 new regression tests
- ✅ All tests pass (139/139)
- ✅ 99.32% code coverage

## Part of
🟠 HIGH: Fix v4.0.0 regressions (select multiple, TypeScript)

This fixes the react-final-form side of react-final-form-arrays#185

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced multi-select form field handling to properly initialize with empty arrays instead of undefined values, ensuring consistent behavior across different select element configurations.

* **Tests**
  * Added comprehensive test coverage for multi-select form field scenarios, validating proper initialization and input value handling for select elements with multiple selection states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->