### PR TITLE
fix: Remove HTMLElement constraint for React Native compatibility

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -58,7 +58,8 @@ export interface FieldRenderProps<
   };
 }
 
-// Re-export FieldMetaState for backwards compatibility (removed in v7.0.0)
+// Re-export of FieldMetaState for backwards compatibility
+// (removed from original sources in v7.0.0 but re-exported here)
 export type FieldMetaState<FieldValue = any> = FieldRenderProps<FieldValue>['meta'];
 
 export interface SubmitEvent {

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,7 +17,7 @@ export interface ReactContext<FormValues = Record<string, any>> {
 
 export interface FieldInputProps<
   FieldValue = any,
-  T extends HTMLElement = HTMLElement,
+  T = any,
 > {
   name: string;
   onBlur: (event?: React.FocusEvent<T>) => void;
@@ -31,7 +31,7 @@ export interface FieldInputProps<
 
 export interface FieldRenderProps<
   FieldValue = any,
-  T extends HTMLElement = HTMLElement,
+  T = any,
   _FormValues = any,
 > {
   input: FieldInputProps<FieldValue, T>;
@@ -57,6 +57,9 @@ export interface FieldRenderProps<
     visited?: boolean;
   };
 }
+
+// Re-export FieldMetaState for backwards compatibility (removed in v7.0.0)
+export type FieldMetaState<FieldValue = any> = FieldRenderProps<FieldValue>['meta'];
 
 export interface SubmitEvent {
   preventDefault?: () => void;
@@ -120,7 +123,7 @@ export interface UseFieldConfig extends UseFieldAutoConfig {
 
 export interface FieldProps<
   FieldValue = any,
-  T extends HTMLElement = HTMLElement,
+  T = any,
   _FormValues = Record<string, any>,
 > extends UseFieldConfig,
     Omit<RenderableProps<FieldRenderProps<FieldValue, T>>, "children"> {

--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -17,7 +17,7 @@ export interface ReactContext<FormValues = Record<string, any>> {
 
 export interface FieldInputProps<
   FieldValue = any,
-  T extends HTMLElement = HTMLElement,
+  T = any,
 > {
   name: string;
   onBlur: (event?: React.FocusEvent<T>) => void;
@@ -31,7 +31,7 @@ export interface FieldInputProps<
 
 export interface FieldRenderProps<
   FieldValue = any,
-  T extends HTMLElement = HTMLElement,
+  T = any,
   _FormValues = any,
 > {
   input: FieldInputProps<FieldValue, T>;
@@ -57,6 +57,9 @@ export interface FieldRenderProps<
     visited?: boolean;
   };
 }
+
+// Re-export FieldMetaState for backwards compatibility (removed in v7.0.0)
+export type FieldMetaState<FieldValue = any> = FieldRenderProps<FieldValue>['meta'];
 
 export interface SubmitEvent {
   preventDefault?: () => void;
@@ -119,7 +122,7 @@ export interface UseFieldConfig extends UseFieldAutoConfig {
 
 export interface FieldProps<
   FieldValue = any,
-  T extends HTMLElement = HTMLElement,
+  T = any,
   _FormValues = Record<string, any>,
 > extends UseFieldConfig,
     Omit<RenderableProps<FieldRenderProps<FieldValue, T>>, "children"> {
@@ -144,7 +147,7 @@ export interface FormSpyPropsWithForm<FormValues = Record<string, any>>
 
 export const Field: <
   FieldValue = any,
-  T extends HTMLElement = HTMLElement,
+  T = any,
   FormValues = Record<string, any>,
 >(
   props: FieldProps<FieldValue, T, FormValues>,
@@ -160,7 +163,7 @@ export const FormSpy: <FormValues = Record<string, any>>(
 
 export function useField<
   FieldValue = any,
-  T extends HTMLElement = HTMLElement,
+  T = any,
   FormValues = Record<string, any>,
 >(
   name: string,

--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -58,7 +58,8 @@ export interface FieldRenderProps<
   };
 }
 
-// Re-export FieldMetaState for backwards compatibility (removed in v7.0.0)
+// Re-export of FieldMetaState for backwards compatibility
+// (removed from original sources in v7.0.0 but re-exported here)
 export type FieldMetaState<FieldValue = any> = FieldRenderProps<FieldValue>['meta'];
 
 export interface SubmitEvent {


### PR DESCRIPTION
## Summary

Fixes #1051

Removes `HTMLElement` type constraint to enable React Native compatibility.

## Problem

In v7.0.0, several type interfaces used `T extends HTMLElement = HTMLElement`, which broke React Native projects since `HTMLElement` is a DOM-specific type not available in React Native.

Affected types:
- `FieldInputProps`
- `FieldRenderProps`
- `FieldProps`
- `Field` component
- `useField` hook

## Solution

Changed the type parameter from `T extends HTMLElement = HTMLElement` to `T = any`:

```typescript
// Before (breaks React Native)
export interface FieldInputProps<FieldValue = any, T extends HTMLElement = HTMLElement>

// After (works everywhere)
export interface FieldInputProps<FieldValue = any, T = any>
```

## Additional improvement

Added `FieldMetaState` type export for better DX:

```typescript
export type FieldMetaState<FieldValue = any> = FieldRenderProps<FieldValue>["meta"];
```

This was previously removed in v7.0.0, forcing users to use the workaround mentioned in #1051.

## Backward Compatibility

✅ **Fully backward compatible**
- Web users can continue using the library exactly as before
- The default `T = any` accepts `HTMLElement` without any changes needed
- No breaking changes to existing code

## Testing

- [x] Types compile without errors
- [x] Web usage unchanged (React.ChangeEvent<HTMLInputElement> still works)
- [x] React Native usage now works (no HTMLElement dependency)
- [x] FieldMetaState type can be imported

## Related

Also partially addresses #1054 by re-exporting `FieldMetaState`.

Fixes #1051


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a FieldMetaState type to expose field metadata in a stable, public API for consumers.

* **Refactor**
  * Loosened type restrictions for form field APIs to increase flexibility and accommodate more element/component patterns while maintaining backwards compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->