### PR TITLE
fix: Support input prop override in Field component

### DIFF
--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -19,6 +19,7 @@ function FieldComponent<
     format,
     formatOnBlur,
     initialValue,
+    input,
     isEqual,
     multiple,
     name,
@@ -52,17 +53,22 @@ function FieldComponent<
     value,
   });
 
+  // Merge provided input prop with field.input
+  const mergedField = input
+    ? { ...field, input: { ...field.input, ...input } }
+    : field;
+
   if (typeof children === "function") {
     return (
       children as (
         props: FieldRenderProps<FieldValue, T> & typeof rest,
       ) => React.ReactNode
-    )({ ...field, ...rest });
+    )({ ...mergedField, ...rest });
   }
 
   if (typeof component === "string") {
     // ignore meta, combine input with any other props
-    const inputProps = { ...field.input };
+    const inputProps = { ...mergedField.input };
 
     // Ensure multiple select has array value
     if (
@@ -86,7 +92,7 @@ function FieldComponent<
   }
 
   return renderComponent(
-    { children, component, ...rest, ...field },
+    { children, component, ...rest, ...mergedField },
     {},
     `Field(${name})`,
   );

--- a/src/types.ts
+++ b/src/types.ts
@@ -126,6 +126,7 @@ export interface FieldProps<
     Omit<RenderableProps<FieldRenderProps<FieldValue, T>>, "children"> {
   name: string;
   children?: RenderableProps<FieldRenderProps<FieldValue, T>>["children"];
+  input?: Partial<FieldInputProps<FieldValue, T>>; // Allow overriding input props
   [key: string]: any; // Allow additional props for HTML elements
 }
 

--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -125,6 +125,7 @@ export interface FieldProps<
     Omit<RenderableProps<FieldRenderProps<FieldValue, T>>, "children"> {
   name: string;
   children?: RenderableProps<FieldRenderProps<FieldValue, T>>["children"];
+  input?: Partial<FieldInputProps<FieldValue, T>>;
   [key: string]: any;
 }
 


### PR DESCRIPTION
## Summary

Fixes #1048

Restores support for the `input` prop on `<Field>` components, which was broken in v7.0.0.

## Problem

In v6.x, users could pass an `input` prop to override or extend field input properties:

```tsx
<Field 
  name="email" 
  component={MyComponent}
  input={{ onChange: customHandler, value: "foo" }}
/>
```

In v7.0.0, this stopped working because the `input` prop wasn't being destructured from props, causing it to end up in `...rest` where it got overridden by `field.input`.

## Solution

- Destructure `input` prop from Field component props
- Merge user-provided `input` with `field.input` (user props take precedence)
- Add `input?: Partial<FieldInputProps>` to `FieldProps` type interface
- Apply merged input to all render paths (children function, string components, custom components)

## Example Usage

```tsx
<Field
  name="email"
  component={MyInput}
  input={{
    onChange: (e) => {
      // Custom onChange logic
      console.log('Custom handler');
    },
    value: customValue,  // Override value
  }}
/>
```

## Testing

- [x] Verified input props are correctly merged
- [x] User-provided input props override field.input props
- [x] Works with all render methods (children function, string component, custom component)
- [x] Types are correct

## Backward Compatibility

✅ **Fully backward compatible**
- Code without `input` prop works exactly as before
- Restores v6.x behavior for code that used `input` prop
- No breaking changes

Fixes #1048


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added optional `input` prop to the Field component, providing enhanced flexibility for customizing field input properties
* Enables developers to supply partial input configurations that override or augment existing field input settings
* Maintains backward compatibility—when the `input` prop is not provided, the Field component behaves as before

<!-- end of auto-generated comment: release notes by coderabbit.ai -->