### PR TITLE
Fix #974: Use parse instead of format in checkbox/radio checked logic

### DIFF
--- a/src/Field.test.js
+++ b/src/Field.test.js
@@ -1249,4 +1249,92 @@ describe("Field", () => {
     }).toThrow("prop name cannot be undefined in <Field> component");
     console.error = consoleError;
   });
+
+  it("should support using format/parse with radio controls", () => {
+    const format = (value) => value && value.toString();
+    const parse = (value) => value && parseInt(value, 10);
+
+    const { getByTestId } = render(
+      <Form onSubmit={onSubmitMock} initialValues={{ number: 20 }}>
+        {({ handleSubmit }) => (
+          <form onSubmit={handleSubmit}>
+            <Field
+              name="number"
+              component="input"
+              type="radio"
+              value={10}
+              data-testid="ten"
+              parse={parse}
+              format={format}
+            />
+            <Field
+              name="number"
+              component="input"
+              type="radio"
+              value={20}
+              data-testid="twenty"
+              parse={parse}
+              format={format}
+            />
+            <Field
+              name="number"
+              component="input"
+              type="radio"
+              value={30}
+              data-testid="thirty"
+              parse={parse}
+              format={format}
+            />
+          </form>
+        )}
+      </Form>,
+    );
+    expect(getByTestId("ten").checked).toBe(false);
+    expect(getByTestId("twenty").checked).toBe(true);
+    expect(getByTestId("thirty").checked).toBe(false);
+  });
+
+  it("should support using format/parse with checkbox controls", () => {
+    const format = (value) => value && value.map((x) => x.toString());
+    const parse = (value) => value && value.map((x) => parseInt(x, 10));
+
+    const { getByTestId } = render(
+      <Form onSubmit={onSubmitMock} initialValues={{ number: [20, 30] }}>
+        {({ handleSubmit }) => (
+          <form onSubmit={handleSubmit}>
+            <Field
+              name="number"
+              component="input"
+              type="checkbox"
+              value={10}
+              data-testid="ten"
+              parse={parse}
+              format={format}
+            />
+            <Field
+              name="number"
+              component="input"
+              type="checkbox"
+              value={20}
+              data-testid="twenty"
+              parse={parse}
+              format={format}
+            />
+            <Field
+              name="number"
+              component="input"
+              type="checkbox"
+              value={30}
+              data-testid="thirty"
+              parse={parse}
+              format={format}
+            />
+          </form>
+        )}
+      </Form>,
+    );
+    expect(getByTestId("ten").checked).toBe(false);
+    expect(getByTestId("twenty").checked).toBe(true);
+    expect(getByTestId("thirty").checked).toBe(true);
+  });
 });

--- a/src/useField.ts
+++ b/src/useField.ts
@@ -27,8 +27,6 @@ const defaultFormat = (value: any, _name: string) =>
 const defaultParse = (value: any, _name: string) =>
   value === "" ? undefined : value;
 
-const defaultIsEqual = (a: any, b: any): boolean => a === b;
-
 function useField<
   FieldValue = any,
   T extends HTMLElement = HTMLElement,

--- a/src/useField.ts
+++ b/src/useField.ts
@@ -209,14 +209,14 @@ function useField<
   const getInputChecked = () => {
     let value = state.value;
     if (type === "checkbox") {
-      value = format(value, name);
+      value = parse(value, name);
       if (_value === undefined) {
         return !!value;
       } else {
         return !!(Array.isArray(value) && ~value.indexOf(_value));
       }
     } else if (type === "radio") {
-      return format(value, name) === _value;
+      return parse(value, name) === _value;
     }
     return undefined;
   };


### PR DESCRIPTION
Fixes #974

## Problem
In `useField.ts`, `getInputChecked()` uses `format(value, name)` to transform the value before comparing to `_value`. But `_value` is in internal format while `format` converts to display format. This causes type mismatches (e.g. comparing string "10" to number 10 fails strict equality).

## Solution
Use `parse` instead of `format` in `getInputChecked()`. This compares the parsed internal value with the raw `_value` attribute, ensuring type consistency.

## Tests
Added tests with numeric radio/checkbox values using format/parse to verify the fix and prevent future regressions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests to verify correct selection state for radio and checkbox controls when forms are initialized with prefilled values.

* **Bug Fixes**
  * Fixed value comparison logic so radio and checkbox controls reflect initial values correctly by applying the proper value transformation during initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->