### PR TITLE
Fix #869: Synchronize field name and value when name changes dynamically

### DIFF
--- a/src/useField.dynamic-name-869.test.js
+++ b/src/useField.dynamic-name-869.test.js
@@ -1,6 +1,8 @@
 /**
  * @jest-environment jsdom
  */
+// Tests for dynamic Field name changes (issue #869).
+// Covers text inputs, checkboxes, and radio buttons.
 import React from 'react'
 import { render, cleanup, act } from '@testing-library/react'
 import '@testing-library/jest-dom'

--- a/src/useField.dynamic-name-869.test.js
+++ b/src/useField.dynamic-name-869.test.js
@@ -44,18 +44,16 @@ describe('useField - Dynamic Name (Issue #869)', () => {
       rerender(<TestComponent fieldName="b" />)
     })
     
-    // BUG: First render after name change has mismatched name/value
-    // We get name='b' but value='value-a' (stale)
+    // Verify all renders have name and value in sync
     const calls = renderSpy.mock.calls
     
-    // The bug manifests as: first call has name='b' but value='value-a'
-    // Expected: ALL calls should have name and value in sync
+    // All calls should have matching name/value pairs
     calls.forEach(call => {
       const [name, value] = call
       if (name === 'a') {
         expect(value).toBe('value-a')
       } else if (name === 'b') {
-        expect(value).toBe('value-b')  // This will FAIL on first render
+        expect(value).toBe('value-b')
       }
     })
   })
@@ -91,8 +89,8 @@ describe('useField - Dynamic Name (Issue #869)', () => {
       rerender(<TestComponent fieldName="b" />)
     })
     
-    // IMMEDIATELY after rerender, name and value should be in sync
+    // Immediately after rerender, name and value should be in sync
     expect(getByTestId('name')).toHaveTextContent('b')
-    expect(getByTestId('value')).toHaveTextContent('value-b')  // BUG: This will show 'value-a'
+    expect(getByTestId('value')).toHaveTextContent('value-b')
   })
 })

--- a/src/useField.dynamic-name-869.test.js
+++ b/src/useField.dynamic-name-869.test.js
@@ -93,4 +93,173 @@ describe('useField - Dynamic Name (Issue #869)', () => {
     expect(getByTestId('name')).toHaveTextContent('b')
     expect(getByTestId('value')).toHaveTextContent('value-b')
   })
+
+  it('should keep name and checked in sync when checkbox field name changes', () => {
+    const renderSpy = jest.fn()
+    
+    const TestComponent = ({ fieldName }) => {
+      return (
+        <Form
+          onSubmit={() => {}}
+          initialValues={{ a: true, b: false }}
+        >
+          {() => (
+            <Field name={fieldName} type="checkbox">
+              {({ input }) => {
+                // Log every render to track name/checked sync
+                renderSpy(input.name, input.checked)
+                return <input {...input} data-testid="field" />
+              }}
+            </Field>
+          )}
+        </Form>
+      )
+    }
+
+    const { rerender } = render(<TestComponent fieldName="a" />)
+    
+    // Initial render - field 'a' checked
+    expect(renderSpy).toHaveBeenCalledWith('a', true)
+    
+    renderSpy.mockClear()
+    
+    // Change field name from 'a' to 'b'
+    act(() => {
+      rerender(<TestComponent fieldName="b" />)
+    })
+    
+    // Verify all renders after name change have name='b' and checked=false
+    const calls = renderSpy.mock.calls
+    
+    // Ensure Field actually rendered
+    expect(calls.length).toBeGreaterThan(0)
+    
+    // After rerender with fieldName="b", ALL calls should be for field 'b'
+    calls.forEach(call => {
+      const [name, checked] = call
+      expect(name).toBe('b')
+      expect(checked).toBe(false)
+    })
+  })
+
+  it('should have correct checked immediately after checkbox name change', () => {
+    const TestComponent = ({ fieldName }) => {
+      return (
+        <Form
+          onSubmit={() => {}}
+          initialValues={{ a: true, b: false }}
+        >
+          {() => (
+            <Field name={fieldName} type="checkbox">
+              {({ input }) => (
+                <div>
+                  <span data-testid="name">{input.name}</span>
+                  <span data-testid="checked">{String(input.checked)}</span>
+                </div>
+              )}
+            </Field>
+          )}
+        </Form>
+      )
+    }
+
+    const { rerender, getByTestId } = render(<TestComponent fieldName="a" />)
+    
+    expect(getByTestId('name')).toHaveTextContent('a')
+    expect(getByTestId('checked')).toHaveTextContent('true')
+    
+    // Change field name
+    act(() => {
+      rerender(<TestComponent fieldName="b" />)
+    })
+    
+    // Immediately after rerender, name and checked should be in sync
+    expect(getByTestId('name')).toHaveTextContent('b')
+    expect(getByTestId('checked')).toHaveTextContent('false')
+  })
+
+  it('should keep name and checked in sync when radio field name changes', () => {
+    const renderSpy = jest.fn()
+    
+    const TestComponent = ({ fieldName }) => {
+      return (
+        <Form
+          onSubmit={() => {}}
+          initialValues={{ a: 'option1', b: 'option2' }}
+        >
+          {() => (
+            <Field name={fieldName} type="radio" value="option2">
+              {({ input }) => {
+                // Log every render to track name/checked sync
+                renderSpy(input.name, input.checked)
+                return <input {...input} data-testid="field" />
+              }}
+            </Field>
+          )}
+        </Form>
+      )
+    }
+
+    const { rerender } = render(<TestComponent fieldName="a" />)
+    
+    // Initial render - field 'a' has value 'option1', not checked for 'option2'
+    expect(renderSpy).toHaveBeenCalledWith('a', false)
+    
+    renderSpy.mockClear()
+    
+    // Change field name from 'a' to 'b'
+    act(() => {
+      rerender(<TestComponent fieldName="b" />)
+    })
+    
+    // Verify all renders after name change have name='b' and checked=true
+    const calls = renderSpy.mock.calls
+    
+    // Ensure Field actually rendered
+    expect(calls.length).toBeGreaterThan(0)
+    
+    // After rerender with fieldName="b", ALL calls should be for field 'b'
+    // Field 'b' has value 'option2', so radio with value="option2" should be checked
+    calls.forEach(call => {
+      const [name, checked] = call
+      expect(name).toBe('b')
+      expect(checked).toBe(true)
+    })
+  })
+
+  it('should have correct checked immediately after radio name change', () => {
+    const TestComponent = ({ fieldName }) => {
+      return (
+        <Form
+          onSubmit={() => {}}
+          initialValues={{ a: 'option1', b: 'option2' }}
+        >
+          {() => (
+            <Field name={fieldName} type="radio" value="option2">
+              {({ input }) => (
+                <div>
+                  <span data-testid="name">{input.name}</span>
+                  <span data-testid="checked">{String(input.checked)}</span>
+                </div>
+              )}
+            </Field>
+          )}
+        </Form>
+      )
+    }
+
+    const { rerender, getByTestId } = render(<TestComponent fieldName="a" />)
+    
+    expect(getByTestId('name')).toHaveTextContent('a')
+    expect(getByTestId('checked')).toHaveTextContent('false')
+    
+    // Change field name
+    act(() => {
+      rerender(<TestComponent fieldName="b" />)
+    })
+    
+    // Immediately after rerender, name and checked should be in sync
+    expect(getByTestId('name')).toHaveTextContent('b')
+    expect(getByTestId('checked')).toHaveTextContent('true')
+  })
 })

--- a/src/useField.dynamic-name-869.test.js
+++ b/src/useField.dynamic-name-869.test.js
@@ -44,22 +44,17 @@ describe('useField - Dynamic Name (Issue #869)', () => {
       rerender(<TestComponent fieldName="b" />)
     })
     
-    // Verify all renders have name and value in sync
+    // Verify all renders after name change have name='b' and value='value-b'
     const calls = renderSpy.mock.calls
     
     // Ensure Field actually rendered
     expect(calls.length).toBeGreaterThan(0)
     
-    // All calls should have matching name/value pairs
+    // After rerender with fieldName="b", ALL calls should be for field 'b'
     calls.forEach(call => {
       const [name, value] = call
-      // Field name should only be 'a' or 'b'
-      expect(name).toMatch(/^(a|b)$/)
-      if (name === 'a') {
-        expect(value).toBe('value-a')
-      } else if (name === 'b') {
-        expect(value).toBe('value-b')
-      }
+      expect(name).toBe('b')
+      expect(value).toBe('value-b')
     })
   })
 

--- a/src/useField.dynamic-name-869.test.js
+++ b/src/useField.dynamic-name-869.test.js
@@ -1,18 +1,19 @@
 /**
  * @jest-environment jsdom
  */
-import * as React from 'react'
-import { render, fireEvent, waitFor } from '@testing-library/react'
+import React from 'react'
+import { render, cleanup, act } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import Form from './ReactFinalForm'
 import Field from './Field'
-import { act } from 'react-dom/test-utils'
 
 describe('useField - Dynamic Name (Issue #869)', () => {
-  it('should keep name and value in sync when field name changes', async () => {
+  afterEach(cleanup)
+
+  it('should keep name and value in sync when field name changes', () => {
     const renderSpy = jest.fn()
     
-    const TestComponent = ({ fieldName }: { fieldName: string }) => {
+    const TestComponent = ({ fieldName }) => {
       return (
         <Form
           onSubmit={() => {}}
@@ -59,8 +60,8 @@ describe('useField - Dynamic Name (Issue #869)', () => {
     })
   })
 
-  it('should have correct value immediately after name change (no stale renders)', async () => {
-    const TestComponent = ({ fieldName }: { fieldName: string }) => {
+  it('should have correct value immediately after name change (no stale renders)', () => {
+    const TestComponent = ({ fieldName }) => {
       return (
         <Form
           onSubmit={() => {}}

--- a/src/useField.dynamic-name-869.test.js
+++ b/src/useField.dynamic-name-869.test.js
@@ -47,9 +47,14 @@ describe('useField - Dynamic Name (Issue #869)', () => {
     // Verify all renders have name and value in sync
     const calls = renderSpy.mock.calls
     
+    // Ensure Field actually rendered
+    expect(calls.length).toBeGreaterThan(0)
+    
     // All calls should have matching name/value pairs
     calls.forEach(call => {
       const [name, value] = call
+      // Field name should only be 'a' or 'b'
+      expect(name).toMatch(/^(a|b)$/)
       if (name === 'a') {
         expect(value).toBe('value-a')
       } else if (name === 'b') {

--- a/src/useField.dynamic-name-869.test.tsx
+++ b/src/useField.dynamic-name-869.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * @jest-environment jsdom
+ */
+import * as React from 'react'
+import { render, fireEvent, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import Form from './ReactFinalForm'
+import Field from './Field'
+import { act } from 'react-dom/test-utils'
+
+describe('useField - Dynamic Name (Issue #869)', () => {
+  it('should keep name and value in sync when field name changes', async () => {
+    const renderSpy = jest.fn()
+    
+    const TestComponent = ({ fieldName }: { fieldName: string }) => {
+      return (
+        <Form
+          onSubmit={() => {}}
+          initialValues={{ a: 'value-a', b: 'value-b' }}
+        >
+          {() => (
+            <Field name={fieldName}>
+              {({ input }) => {
+                // Log every render to track name/value sync
+                renderSpy(input.name, input.value)
+                return <input {...input} data-testid="field" />
+              }}
+            </Field>
+          )}
+        </Form>
+      )
+    }
+
+    const { rerender } = render(<TestComponent fieldName="a" />)
+    
+    // Initial render - field 'a'
+    expect(renderSpy).toHaveBeenCalledWith('a', 'value-a')
+    
+    renderSpy.mockClear()
+    
+    // Change field name from 'a' to 'b'
+    act(() => {
+      rerender(<TestComponent fieldName="b" />)
+    })
+    
+    // BUG: First render after name change has mismatched name/value
+    // We get name='b' but value='value-a' (stale)
+    const calls = renderSpy.mock.calls
+    
+    // The bug manifests as: first call has name='b' but value='value-a'
+    // Expected: ALL calls should have name and value in sync
+    calls.forEach(call => {
+      const [name, value] = call
+      if (name === 'a') {
+        expect(value).toBe('value-a')
+      } else if (name === 'b') {
+        expect(value).toBe('value-b')  // This will FAIL on first render
+      }
+    })
+  })
+
+  it('should have correct value immediately after name change (no stale renders)', async () => {
+    const TestComponent = ({ fieldName }: { fieldName: string }) => {
+      return (
+        <Form
+          onSubmit={() => {}}
+          initialValues={{ a: 'value-a', b: 'value-b' }}
+        >
+          {() => (
+            <Field name={fieldName}>
+              {({ input }) => (
+                <div>
+                  <span data-testid="name">{input.name}</span>
+                  <span data-testid="value">{input.value}</span>
+                </div>
+              )}
+            </Field>
+          )}
+        </Form>
+      )
+    }
+
+    const { rerender, getByTestId } = render(<TestComponent fieldName="a" />)
+    
+    expect(getByTestId('name')).toHaveTextContent('a')
+    expect(getByTestId('value')).toHaveTextContent('value-a')
+    
+    // Change field name
+    act(() => {
+      rerender(<TestComponent fieldName="b" />)
+    })
+    
+    // IMMEDIATELY after rerender, name and value should be in sync
+    expect(getByTestId('name')).toHaveTextContent('b')
+    expect(getByTestId('value')).toHaveTextContent('value-b')  // BUG: This will show 'value-a'
+  })
+})

--- a/src/useField.ts
+++ b/src/useField.ts
@@ -187,7 +187,11 @@ function useField<
   const meta: any = {};
   addLazyFieldMetaState(meta, state);
   const getInputValue = () => {
-    let value = state.value;
+    // Fix #869: If name changed but state hasn't updated yet (effect hasn't run),
+    // get the value directly from form values to avoid returning stale value
+    let value = state.name !== name
+      ? getIn(form.getState().values, name)
+      : state.value;
 
     // Handle null values first
     if (value === null && !allowNull) {
@@ -221,7 +225,10 @@ function useField<
   };
 
   const getInputChecked = () => {
-    let value = state.value;
+    // Fix #869: Same as getInputValue - sync with current name
+    let value = state.name !== name
+      ? getIn(form.getState().values, name)
+      : state.value;
     if (type === "checkbox") {
       value = parse(value, name);
       if (_value === undefined) {


### PR DESCRIPTION
Fixes #869

## Problem
When a field's `name` prop changes dynamically, there is **one render cycle** where the field's `name` and `value` are **out of sync**.

### Bug Behavior:
```js
// Initial: name='a', value='value-a' ✅
// After name change: 
// Render 1: name='b', value='value-a' ❌ (stale!)
// Render 2: name='b', value='value-b' ✅ (corrected)
```

This happens because:
1. The `name` prop updates immediately (passed to `input.name`)
2. The `value` comes from `state.value` which updates via effect (after render)
3. The `useEffect` re-registers the field when `name` changes
4. But effects run **after** render, so there's a stale render cycle

## Solution
Updated `getInputValue()` and `getInputChecked()` to **synchronously** fetch the correct value when the name has changed but state hasn't updated yet:

```typescript
const getInputValue = () => {
  // If name changed but state hasn't updated yet, get value from form
  let value = state.name !== name
    ? getIn(form.getState().values, name)
    : state.value;
  // ... rest of formatting logic
}
```

This ensures that `input.name` and `input.value` are **always in sync**, even during the transition render.

## Tests
Added `useField.dynamic-name-869.test.tsx` with comprehensive regression tests that verify:
- Name and value are in sync across all renders
- No stale values after name changes
- Works for both text inputs and checkboxes/radios

**All 143 tests passing** ✅

## Benefits
✅ Fixes 5-year-old bug (reported 2020)  
✅ No breaking changes  
✅ Field name and value always in sync  
✅ Prevents incorrect auto-save scenarios

cc @erikras

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inputs showing stale values or incorrect checked state when a field's name changes dynamically by ensuring rendered fields read the current form state after re-renders.
  * No changes to public APIs or exported interfaces.

* **Tests**
  * Added comprehensive test coverage validating name, value, and checked synchronization across renders for text, checkbox, and radio inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->