### PR TITLE
fix: add null guards on formState.values in getIn calls (TS2345)

### DIFF
--- a/src/useField.ts
+++ b/src/useField.ts
@@ -212,7 +212,7 @@ function useField<
       
       // Only update if the new initialValue differs from current form initial
       if (!isEqual(initialValue, currentFormInitial)) {
-        const currentValue = getIn(formState.values, name);
+        const currentValue = formState.values ? getIn(formState.values, name) : undefined;
         
         // If the current value matches the new initial value, update the form's
         // initialValues to reflect this. This is needed for radio buttons where
@@ -271,7 +271,7 @@ function useField<
     // Fix #869: If name changed but state hasn't updated yet (effect hasn't run),
     // get the value directly from form values to avoid returning stale value
     let value = state.name !== name
-      ? getIn(form.getState().values, name)
+      ? getIn(form.getState().values ?? {}, name)
       : state.value;
 
     // Handle null values first
@@ -308,7 +308,7 @@ function useField<
   const getInputChecked = () => {
     // Fix #869: Same as getInputValue - sync with current name
     let value = state.name !== name
-      ? getIn(form.getState().values, name)
+      ? getIn(form.getState().values ?? {}, name)
       : state.value;
     if (type === "checkbox") {
       value = parse(value, name);


### PR DESCRIPTION
`formState.values` and `form.getState().values` are typed as `FormValues | undefined` in final-form's types, but `getIn` expects `object`, causing TS2345 errors at build time. Added null guards at all three call sites in `useField.ts`.

This fix was missing from the v7.0.1 release PR — needs to land on `main` so the tag can be updated before npm publish.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced form field state synchronization to safely handle scenarios where field names change before the form state updates. Improved handling of undefined form values to prevent errors and ensure consistent, reliable field value reading and input state management during form operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->