### PR TITLE
Add FieldRenderProps excess prop type coverage

### DIFF
--- a/typescript/Field.test.tsx
+++ b/typescript/Field.test.tsx
@@ -32,3 +32,22 @@ function FieldNumberInputValue() {
     </Field>
   );
 }
+
+interface TextInputProps extends FieldRenderProps<string, HTMLInputElement> {
+  label: string;
+}
+
+const TextInput: React.FC<TextInputProps> = () => null;
+
+function FieldRenderPropsDoesNotAllowArbitraryProps({
+  input,
+  meta,
+}: FieldRenderProps<string, HTMLInputElement>) {
+  return (
+    <>
+      <TextInput input={input} meta={meta} label="First name" />
+      {/* @ts-expect-error FieldRenderProps should not add an index signature */}
+      <TextInput input={input} meta={meta} label="First name" extra="ignored" />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add a TypeScript definitions regression test asserting FieldRenderProps does not allow arbitrary extra props through an index signature
- covers GH#990; the current declarations already omit the FieldRenderProps index signature, so this locks in the fixed behavior

Fixes #990

## Tests
- yarn nps build
- yarn nps typescript.definitions
- yarn nps typescript
- yarn test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved TypeScript type-checking coverage for form field rendering properties to enforce proper prop usage and enhance type safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->