### PR TITLE
Add regression coverage for formatOnBlur submit field state

### DIFF
--- a/src/Field.test.js
+++ b/src/Field.test.js
@@ -1091,6 +1091,39 @@ describe("Field", () => {
     expect(onSubmit.mock.calls[1][0]).toEqual({ name: "ERIKRAS" });
   });
 
+  it("should not throw when formatOnBlur beforeSubmit runs after field state is removed", () => {
+    const onSubmit = jest.fn();
+    let formApi;
+    const { getByTestId, getByText } = render(
+      <Form onSubmit={onSubmit}>
+        {({ form, handleSubmit }) => {
+          formApi = form;
+          return (
+            <form onSubmit={handleSubmit}>
+              <Field
+                name="url"
+                component="input"
+                format={(value) => value && value.trim()}
+                formatOnBlur
+                data-testid="url"
+              />
+              <button type="submit">Submit</button>
+            </form>
+          );
+        }}
+      </Form>,
+    );
+
+    fireEvent.change(getByTestId("url"), { target: { value: " test " } });
+    const originalGetFieldState = formApi.getFieldState;
+    formApi.getFieldState = jest.fn(() => undefined);
+
+    expect(() => fireEvent.click(getByText("Submit"))).not.toThrow();
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+
+    formApi.getFieldState = originalGetFieldState;
+  });
+
   it("should allow submission to be cancelled in beforeSubmit", () => {
     const onSubmit = jest.fn();
     const beforeSubmit = jest.fn(() => false);


### PR DESCRIPTION
## Summary
- Add regression coverage for GH#981 around `formatOnBlur` submit handling when a field's state is no longer available.
- Confirms submit no longer throws if `beforeSubmit` runs after the field state has been removed.

## Verification
- `NODE_ENV=test npx jest src/Field.test.js -t "should not throw when formatOnBlur beforeSubmit" --runInBand`
- `yarn test`

Fixes #981


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for edge cases in form submission handling to ensure robust behavior when field state is unavailable during cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->