### PR TITLE
Fix #1093: useField read current value on the render

### DIFF
--- a/src/useField.test.js
+++ b/src/useField.test.js
@@ -599,6 +599,38 @@ describe("useField", () => {
     expect(getByTestId("array").value).toBe("Apple");
   });
 
+  it("should return current form values on first render for newly added array fields", () => {
+    const renderSpy = jest.fn();
+    const MyField = () => {
+      const { input, meta } = useField("items[0].name");
+      renderSpy(input.value, meta.initial, meta.dirty);
+      return <input {...input} data-testid="array" />;
+    };
+    const { getByTestId } = render(
+      <Form onSubmit={onSubmitMock} initialValues={{ items: [] }}>
+        {({ form, values }) => (
+          <form>
+            <button
+              type="button"
+              data-testid="add"
+              onClick={() => form.change("items", [{ name: "Apple" }])}
+            >
+              Add
+            </button>
+            {values.items.map((_item, index) => (
+              <MyField key={index} />
+            ))}
+          </form>
+        )}
+      </Form>,
+    );
+
+    fireEvent.click(getByTestId("add"));
+
+    expect(renderSpy.mock.calls[0]).toEqual(["Apple", undefined, true]);
+    expect(getByTestId("array").value).toBe("Apple");
+  });
+
   it("should default undefined value to [] for select multiple with type prop (fix react-final-form-arrays #185)", () => {
     const renderSpy = jest.fn();
     const MySelectField = () => {

--- a/src/useField.ts
+++ b/src/useField.ts
@@ -124,7 +124,12 @@ function useField<
     // Use Form initialValues if available, otherwise use field initialValue
     let initialStateValue = formInitialValue !== undefined ? formInitialValue : initialValue;
 
-    let value = formValue !== undefined ? formValue : initialStateValue;
+    let value =
+      formInitialValue !== undefined
+        ? formValue
+        : formValue !== undefined
+          ? formValue
+          : initialStateValue;
 
     if ((component === "select" || type === "select") && multiple) {
       if (value === undefined && initialStateValue === undefined) {
@@ -133,10 +138,15 @@ function useField<
         initialStateValue = emptyValue;
       } else {
         if (value === undefined) {
-          value = [];
+          value =
+            Array.isArray(initialStateValue) && initialStateValue.length === 0
+              ? initialStateValue
+              : [];
         }
+
         if (initialStateValue === undefined) {
-          initialStateValue = [];
+          initialStateValue =
+            Array.isArray(value) && value.length === 0 ? value : [];
         }
       }
     }

--- a/src/useField.ts
+++ b/src/useField.ts
@@ -116,13 +116,32 @@ function useField<
     const formState = form.getState();
     // Use getIn to support nested field paths like "user.name" or "items[0].id"
     const formInitialValue = formState.initialValues ? getIn(formState.initialValues, name) : undefined;
-    
+  
+    const formValue = formState.values
+      ? getIn(formState.values, name)
+      : undefined;
+
     // Use Form initialValues if available, otherwise use field initialValue
     let initialStateValue = formInitialValue !== undefined ? formInitialValue : initialValue;
-    
-    if ((component === "select" || type === "select") && multiple && initialStateValue === undefined) {
-      initialStateValue = [];
+
+    let value = formValue !== undefined ? formValue : initialStateValue;
+
+    if ((component === "select" || type === "select") && multiple) {
+      if (value === undefined && initialStateValue === undefined) {
+        const emptyValue: any[] = [];
+        value = emptyValue;
+        initialStateValue = emptyValue;
+      } else {
+        if (value === undefined) {
+          value = [];
+        }
+        if (initialStateValue === undefined) {
+          initialStateValue = [];
+        }
+      }
     }
+    const isEqual = configRef.current.isEqual || ((a: any, b: any) => a === b);
+    const pristine = isEqual(value, initialStateValue);
 
     return {
       active: false,
@@ -133,7 +152,7 @@ function useField<
         form.change(name as keyof FormValues, value);
       },
       data: data || {},
-      dirty: false,
+      dirty: !pristine,
       dirtySinceLastSubmit: false,
       error: undefined,
       focus: () => {
@@ -145,7 +164,7 @@ function useField<
       modified: false,
       modifiedSinceLastSubmit: false,
       name,
-      pristine: true,
+      pristine,
       submitError: undefined,
       submitFailed: false,
       submitSucceeded: false,
@@ -153,7 +172,7 @@ function useField<
       touched: false,
       valid: true,
       validating: false,
-      value: initialStateValue,
+      value,
       visited: false,
     };
   });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved initial field state handling so newly added fields (including array paths) display the current value immediately.
  * Corrected dirty/pristine tracking, including more consistent behavior for multi-select fields, so state accurately reflects whether values changed.
* **Tests**
  * Added a test to confirm that newly created array fields render the expected value on first render and that state flags (e.g., dirty/initial) are set correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->